### PR TITLE
fix: Catch staff profile without pool informations

### DIFF
--- a/api/graphs/api.graphqls
+++ b/api/graphs/api.graphqls
@@ -75,6 +75,7 @@ input CreateUserInput {
   poolYear: String!
   poolMonth: String!
   phone: String!
+  isStaff: Boolean!
 }
 
 input LinkAccountInput {

--- a/internal/api/api.resolvers.go
+++ b/internal/api/api.resolvers.go
@@ -31,6 +31,7 @@ func (r *mutationResolver) InternalCreateUser(ctx context.Context, input typesge
 		SetPoolYear(input.PoolYear).
 		SetPoolMonth(input.PoolMonth).
 		SetPhone(input.Phone).
+		SetIsStaff(input.IsStaff).
 		OnConflictColumns(user.FieldDuoID).
 		UpdateDuoID().
 		ID(ctx)

--- a/internal/models/schema/user.go
+++ b/internal/models/schema/user.go
@@ -29,12 +29,13 @@ func (User) Fields() []ent.Field {
 		field.String("first_name").NotEmpty().MaxLen(255),
 		field.String("usual_first_name").Nillable().Optional().MaxLen(255),
 		field.String("last_name").NotEmpty().MaxLen(255),
-		field.String("phone").MaxLen(255),
-		field.String("pool_year"),
-		field.String("pool_month"),
+		field.String("phone").Optional().Nillable().MaxLen(255),
+		field.String("pool_year").Optional().Nillable(),
+		field.String("pool_month").Optional().Nillable(),
 		field.String("nickname").Optional().Nillable().Unique().MaxLen(255),
 		field.String("avatar_url").Optional().Nillable().MaxLen(255),
 		field.String("cover_url").Optional().Nillable().MaxLen(255),
+		field.Bool("is_staff").Default(false),
 	}
 }
 

--- a/web/ui/src/graphql/definitions.gql
+++ b/web/ui/src/graphql/definitions.gql
@@ -33,6 +33,7 @@ mutation internalCreateUser(
   $poolYear: String!
   $poolMonth: String!
   $phone: String!
+  $isStaff: Boolean!
 ) {
   internalCreateUser(
     input: {
@@ -45,6 +46,7 @@ mutation internalCreateUser(
       poolYear: $poolYear
       poolMonth: $poolMonth
       phone: $phone
+      isStaff: $isStaff
     }
   )
 }

--- a/web/ui/src/lib/GraphqlAdapter/graphql-adapter.ts
+++ b/web/ui/src/lib/GraphqlAdapter/graphql-adapter.ts
@@ -71,6 +71,7 @@ export const GraphQLAdapter = (): S42Adapter => {
             poolYear: typedUser.duo.poolYear,
             poolMonth: typedUser.duo.poolMonth,
             phone: typedUser.duo.phone,
+            isStaff: typedUser.duo.isStaff,
           },
           { Authorization: `ServiceToken ${getServiceToken()}` }
         );

--- a/web/ui/src/lib/GraphqlAdapter/types.d.ts
+++ b/web/ui/src/lib/GraphqlAdapter/types.d.ts
@@ -55,6 +55,7 @@ export interface DuoContext {
   poolYear: string;
   poolMonth: string;
   phone: string;
+  isStaff: boolean;
 }
 
 export interface GithubContext {

--- a/web/ui/src/pages/api/auth/[...nextauth].ts
+++ b/web/ui/src/pages/api/auth/[...nextauth].ts
@@ -99,6 +99,7 @@ export default NextAuth({
           poolYear: profile.pool_year,
           poolMonth: profile.pool_month,
           phone: profile.phone,
+          isStaff: profile['staff?'] || false,
         };
         return true;
       } else if (account.provider == 'github') {


### PR DESCRIPTION
**Relative Issues:** Resolve #83 

**Describe the pull request**
When a staff try to connect to app, no information relative to pool is sended and make a crash

**Checklist**

- [x] I have linked the relative issue to this pull request
- [ ] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no
