### PR TITLE
chore: pass webui depsday to only 1 per month

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       - state/triage 🚦
     schedule:
       day: sunday
-      interval: weekly
+      interval: monthly
   - package-ecosystem: gomod
     directory: /
     labels:
@@ -24,7 +24,7 @@ updates:
       - state/triage 🚦
     schedule:
       day: sunday
-      interval: weekly
+      interval: monthly
   - package-ecosystem: npm
     directory: /web/ui
     labels:
@@ -33,5 +33,4 @@ updates:
       - domain/obvious 🟩
       - state/triage 🚦
     schedule:
-      day: sunday
-      interval: weekly
+      interval: monthly


### PR DESCRIPTION
**Describe the pull request**

Too many update each week with repeated update of few packages. Reduce the deps update by passing the NPM update to the first of each day 

**Checklist**

- [ ] I have linked the relative issue to this pull request
- [ ] I have made the modifications or added tests related to my PR
- [ ] I have added/updated the documentation for my RP
- [ ] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
yes/no

**Additional context**
<!-- Add any other context about your PR here. -->
