### PR TITLE
fix: duo api have two different formats

### DIFF
--- a/pkg/duoapi/time.go
+++ b/pkg/duoapi/time.go
@@ -14,7 +14,11 @@ func (dt *DuoTime) UnmarshalJSON(b []byte) error {
 	s := strings.Trim(string(b), "\"")
 	t, err := time.Parse(duoTimeFormat, s)
 	if err != nil {
-		return err
+		t2, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			return err
+		}
+		t = t2
 	}
 	*dt = DuoTime(t)
 	return nil


### PR DESCRIPTION
**Describe the pull request**

The Duo API have two different format of date. On Location object the time format must be `2006-01-02 15:04:05 MST` or `2006-01-02T15:04:05Z07:00`. We needs to catch and transform the both time format because the intranet dont follow any RFC.

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no

**Additional context**
```
12:24PM FTL Failed to get duoapi response error="parsing time \"2022-07-02T12:23:38.279Z\" as \"2006-01-02 15:04:05 MST\": cannot parse \"T12:23:38.279Z\" as \" \"" version=latest
```