### PR TITLE
fix: processor crashes when location dont exist yet

### DIFF
--- a/internal/webhooks/location.go
+++ b/internal/webhooks/location.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	modelsutils "atomys.codes/stud42/internal/models"
+	"atomys.codes/stud42/internal/models/generated"
 	"atomys.codes/stud42/internal/models/generated/campus"
 	"atomys.codes/stud42/internal/models/generated/location"
 	"atomys.codes/stud42/internal/models/generated/user"
@@ -65,7 +66,7 @@ func (p *locationProcessor) Close(loc *duoapi.Location[duoapi.LocationUser], met
 		SetIdentifier(loc.Host).
 		Where(location.DuoID(loc.ID)).
 		Exec(p.ctx)
-	if err != nil {
+	if err != nil && !generated.IsNotFound(err) {
 		return err
 	}
 
@@ -77,7 +78,7 @@ func (p *locationProcessor) Close(loc *duoapi.Location[duoapi.LocationUser], met
 func (p *locationProcessor) Destroy(loc *duoapi.Location[duoapi.LocationUser], metadata *duoapi.WebhookMetadata) error {
 	// Delete the location in database
 	_, err := p.db.Location.Delete().Where(location.DuoID(loc.ID)).Exec(p.ctx)
-	if err != nil {
+	if err != nil && !generated.IsNotFound(err) {
 		return err
 	}
 	


### PR DESCRIPTION
**Describe the pull request**

When a location is created and closed at the same time, the location can be closed before is created in database. This event will crash the processor

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no

**Additional context**
<!-- Add any other context about your PR here. -->
