### PR TITLE
chore: Configure jwtks service accessible from sandbox for local dev

### DIFF
--- a/config/stud42.example.yaml
+++ b/config/stud42.example.yaml
@@ -16,7 +16,7 @@ jwtks:
     #
     # In production, the JWTKS endpoint is a HTTPS endpoint. Accessible
     # to the public.
-    sets: http://127.0.0.1:5500/jwks
+    sets: https://sandbox.s42.dev/.well-known/jwks
     # The endpoint used to retrieve the public key for the JWT token.
     # This endpoint is a gRPC endpoint. In order to use this endpoint,
     # the `jwtks-service` must be running. If you have access to the DEVENV
@@ -26,7 +26,7 @@ jwtks:
     # In production, the endpoint should be `secure` and use a TLS
     # certificate. The communication with the signing server is cluster
     # specific and cannot be called from outside the cluster.
-    sign: localhost:5000
+    sign: sandbox.s42.dev:51000
   # Certs used to sign and validate the JWT
   # Also called : The JWK
   jwk:

--- a/deploy/app/jwtks-service/base/deployment.yaml
+++ b/deploy/app/jwtks-service/base/deployment.yaml
@@ -44,8 +44,10 @@ spec:
             memory: "42Mi"
             cpu: "200m"
         ports:
-        - containerPort: 5000
-        - containerPort: 5500
+        - name: grpc
+          containerPort: 5000
+        - name: http
+          containerPort: 5500
       volumes:
       - name: certs-grpc
         secret:

--- a/deploy/app/jwtks-service/base/service.yaml
+++ b/deploy/app/jwtks-service/base/service.yaml
@@ -4,7 +4,8 @@ metadata:
   name: grpc-jwtks-service
 spec:
   ports:
-  - port: 5000
+  - name: grpc-jwtks-service
+    port: 5000
     targetPort: 5000
 ---
 apiVersion: v1
@@ -13,5 +14,6 @@ metadata:
   name: http-jwtks-service
 spec:
   ports:
-  - port: 5500
+  - name: http-jwtks-service
+    port: 5500
     targetPort: 5500

--- a/deploy/app/jwtks-service/overlays/sandbox/sandbox-grpc-virtual-service.yaml
+++ b/deploy/app/jwtks-service/overlays/sandbox/sandbox-grpc-virtual-service.yaml
@@ -5,14 +5,13 @@ metadata:
   namespace: sandbox
 spec:
   hosts:
-  - sandbox.s42.dev
+  - '*'
   gateways:
-  - s42-dev-sandbox
   - s42-dev-sandbox-grpc
   http:
-  - name: grpc-jwtks-service
-    match:
-    - port: 51000
+  - match:
+    - uri:
+        prefix: /
     route:
     - destination:
         host: sand-grpc-jwtks-service

--- a/deploy/cluster/istio/gateways/s42-dev-sandbox-grpc.yaml
+++ b/deploy/cluster/istio/gateways/s42-dev-sandbox-grpc.yaml
@@ -7,9 +7,9 @@ spec:
   selector:
     istio: ingressgateway # use istio default controller
   servers:
-    - port:
-        number: 51000
-        name: grpc
-        protocol: GRPC
-      hosts:
-      - "sandbox.s42.dev"
+  - port:
+      number: 51000
+      name: grpc
+      protocol: GRPC
+    hosts:
+    - sandbox.s42.dev

--- a/deploy/cluster/namespaces/production.yaml
+++ b/deploy/cluster/namespaces/production.yaml
@@ -6,6 +6,6 @@ metadata:
   name: production
   labels:
     kubernetes.io/name: live
-    pod-security.kubernetes.io/enforce: restricted
-    pod-security.kubernetes.io/enforce-version: '1.23'
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: 'v1.23'
     app.kubernetes.io/created-by: github-actions

--- a/deploy/cluster/namespaces/review-apps.yaml
+++ b/deploy/cluster/namespaces/review-apps.yaml
@@ -9,5 +9,5 @@ metadata:
   labels:
     kubernetes.io/name: review-apps
     pod-security.kubernetes.io/warn-enforce: restricted
-    pod-security.kubernetes.io/warn-enforce-version: '1.23'
+    pod-security.kubernetes.io/warn-enforce-version: 'v1.23'
     app.kubernetes.io/created-by: github-actions

--- a/deploy/cluster/namespaces/sandbox.yaml
+++ b/deploy/cluster/namespaces/sandbox.yaml
@@ -9,5 +9,5 @@ metadata:
   labels:
     kubernetes.io/name: sandbox
     pod-security.kubernetes.io/warn-enforce: restricted
-    pod-security.kubernetes.io/warn-enforce-version: '1.23'
+    pod-security.kubernetes.io/warn-enforce-version: 'v1.23'
     app.kubernetes.io/created-by: github-actions

--- a/deploy/cluster/namespaces/staging.yaml
+++ b/deploy/cluster/namespaces/staging.yaml
@@ -6,6 +6,6 @@ metadata:
   name: staging
   labels:
     kubernetes.io/name: next
-    pod-security.kubernetes.io/enforce: restricted
-    pod-security.kubernetes.io/enforce-version: '1.23'
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: 'v1.23'
     app.kubernetes.io/created-by: github-actions


### PR DESCRIPTION
**Relative Issues:** Resolve #166

**Describe the pull request**
The Sandbox JWTKS Service is normally defined to be accessible for everyone to allow developers to develop on s42 easier. At this moment, the service run correctly but is not accessible from outside of k8s cluster.

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no

**Additional context**
<!-- Add any other context about your PR here. -->
