### PR TITLE
fix: friends query dont use new avatar url field

### DIFF
--- a/web/ui/src/graphql/definitions.gql
+++ b/web/ui/src/graphql/definitions.gql
@@ -135,6 +135,7 @@ query myFollowings {
       }
     }
     ...UserIdentyData
+    duoAvatarURL
   }
 }
 

--- a/web/ui/src/pages/friends/index.tsx
+++ b/web/ui/src/pages/friends/index.tsx
@@ -1,13 +1,12 @@
-import React from 'react';
-import { Menu, MenuCategory, MenuItem, useSidebar } from '@components/Sidebar';
-import classNames from 'classnames';
-import Head from 'next/head';
-import { NextPage } from 'next';
-import UserCard from '@components/UserCard';
-import { Search } from '@components/Search';
-import { MyFollowingsDocument, useMyFollowingsQuery, User } from '@graphql.d';
 import Loader from '@components/Loader';
+import { Search } from '@components/Search';
+import { Menu, MenuCategory, MenuItem, useSidebar } from '@components/Sidebar';
+import UserCard from '@components/UserCard';
+import { MyFollowingsDocument, useMyFollowingsQuery, User } from '@graphql.d';
 import { isFirstLoading } from '@lib/apollo';
+import classNames from 'classnames';
+import { NextPage } from 'next';
+import Head from 'next/head';
 
 type PageProps = {};
 


### PR DESCRIPTION
**Relative Issues:** https://discord.com/channels/248936708379246593/999457033667489974

**Describe the pull request**

Friend list dont call the new field `duoAvatarURL` and use the fallback avatar generator 

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no
