### PR TITLE
fix: tooltip overlap with under content

### DIFF
--- a/web/ui/src/components/Tooltip/Tooltip.tsx
+++ b/web/ui/src/components/Tooltip/Tooltip.tsx
@@ -33,15 +33,17 @@ export const Tooltip = ({
     >
       <div
         className={classNames(
-          visible ? 'opacity-100 z-10 ml-4' : '-z-10 opacity-0 ml-1',
-          'hidden md:flex absolute left-full bg-gradient-to-r from-indigo-600 to-indigo-500 text-slate-100 dark:text-slate-300 px-4 py-2 rounded transition-all duration-150',
+          visible
+            ? 'opacity-100 z-10 ml-4 md:flex'
+            : 'hidden -z-10 opacity-0 ml-1',
+          'absolute left-full bg-gradient-to-r from-indigo-600 to-indigo-500 text-slate-100 dark:text-slate-300 px-4 py-2 rounded transition-all duration-150',
           'max-w-[250px] flex-col w-max items-start'
         )}
         data-testid="tooltip"
       >
         {showArrow && (
           <div
-            className="bg-indigo-600 absolute w-3 h-3 whitespace-nowrap"
+            className="bg-indigo-600 absolute w-3 h-3 top-1/3 whitespace-nowrap"
             style={{ left: '-6px', transform: 'rotate(45deg)' }}
           />
         )}

--- a/web/ui/src/components/Tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/web/ui/src/components/Tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -7,11 +7,11 @@ exports[`snapshot: renders Tooltip unchanged 1`] = `
     data-testid="hover-target"
   >
     <div
-      class="-z-10 opacity-0 ml-1 hidden md:flex absolute left-full bg-gradient-to-r from-indigo-600 to-indigo-500 text-slate-100 dark:text-slate-300 px-4 py-2 rounded transition-all duration-150 max-w-[250px] flex-col w-max items-start"
+      class="hidden -z-10 opacity-0 ml-1 absolute left-full bg-gradient-to-r from-indigo-600 to-indigo-500 text-slate-100 dark:text-slate-300 px-4 py-2 rounded transition-all duration-150 max-w-[250px] flex-col w-max items-start"
       data-testid="tooltip"
     >
       <div
-        class="bg-indigo-600 absolute w-3 h-3 whitespace-nowrap"
+        class="bg-indigo-600 absolute w-3 h-3 top-1/3 whitespace-nowrap"
         style="left: -6px; transform: rotate(45deg);"
       />
       <span


### PR DESCRIPTION
**Describe the pull request**

The tooltip is not hidden and block the user to interact with under content

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no
