### PR TITLE
feat: account callbacks will invite user on discord and star repository

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/getsentry/sentry-go v0.13.0
 	github.com/go-chi/chi v1.5.4
 	github.com/go-chi/chi/v5 v5.0.7
+	github.com/google/go-github/v47 v47.0.1-0.20220822225427-243bda850b1f
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/lestrrat-go/jwx/v2 v2.0.0-beta2
@@ -46,6 +47,7 @@ require (
 	github.com/goccy/go-json v0.9.6 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/graphql-go/graphql v0.7.10-0.20210411022516-8a92e977c10b // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -189,10 +189,15 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-github/v47 v47.0.1-0.20220822225427-243bda850b1f h1:8D2wmvSVxLueygUFs2Z+6iOsfo4XP0/ggzfI73GtmTc=
+github.com/google/go-github/v47 v47.0.1-0.20220822225427-243bda850b1f/go.mod h1:DRjdvizXE876j0YOZwInB1ESpOcU/xFBClNiQLSdorE=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=

--- a/internal/api/account_callbacks.go
+++ b/internal/api/account_callbacks.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"context"
+
+	typesgen "atomys.codes/stud42/internal/api/generated/types"
+	"atomys.codes/stud42/internal/discord"
+	modelgen "atomys.codes/stud42/internal/models/generated"
+	"github.com/getsentry/sentry-go"
+	"github.com/google/go-github/v47/github"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/oauth2"
+)
+
+const (
+	// githubCreator is the GitHub username of the creator of the repository.
+	githubCreator = "42Atomys"
+	// githubRepository is the GitHub repository name.
+	githubRepository = "stud42"
+)
+
+// accountLinkCallback is the callback for all accounts. This is used to define
+// an asynchronous callback for each account type that will be called when the
+// account is linked to a user.
+func accountLinkCallback(ctx context.Context, account *modelgen.Account) {
+	switch account.Type {
+	case string(typesgen.ProviderDiscord):
+		discordLinkCallback(ctx, account)
+	case string(typesgen.ProviderGithub):
+		githubLinkCallback(ctx, account)
+	case string(typesgen.ProviderDuo):
+		break
+	default:
+		log.Warn().Str("accountType", account.Type).Msg("no callback is defined")
+	}
+}
+
+// discordLinkCallback is the callback for Discord accounts when the account is
+// linked to a user. It will add the user to the Discord server.
+func discordLinkCallback(ctx context.Context, account *modelgen.Account) {
+	// Invite the user to the S42 server using the Discord API
+	err := discord.
+		DefaultClient().
+		InviteOnOurDiscord(ctx, account.AccessToken, account.ProviderAccountID)
+	if err != nil {
+		sentry.CaptureException(err)
+	}
+}
+
+// githubLinkCallback is the callback for Github accounts when the account is
+// linked to a user. It will follow the creator of the repository and star
+// the repository.
+func githubLinkCallback(ctx context.Context, account *modelgen.Account) {
+	client := github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: account.AccessToken},
+	)))
+
+	// Star the repository if it's not already starred
+	var err error
+	var ok bool
+	if ok, _, err = client.Activity.IsStarred(ctx, githubCreator, githubRepository); !ok {
+		_, err = client.Activity.Star(ctx, githubCreator, githubRepository)
+	}
+	if err != nil {
+		sentry.CaptureException(err)
+	}
+
+	// Follow th creator if it's not already followed
+	if ok, _, err = client.Users.IsFollowing(ctx, "", githubCreator); !ok {
+		_, err = client.Users.Follow(ctx, githubCreator)
+	}
+	if err != nil {
+		sentry.CaptureException(err)
+	}
+}

--- a/internal/api/api.resolvers.go
+++ b/internal/api/api.resolvers.go
@@ -6,13 +6,13 @@ package api
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
 
 	apigen "atomys.codes/stud42/internal/api/generated"
 	typesgen "atomys.codes/stud42/internal/api/generated/types"
+	"atomys.codes/stud42/internal/discord"
 	modelsutils "atomys.codes/stud42/internal/models"
 	"atomys.codes/stud42/internal/models/generated"
 	"atomys.codes/stud42/internal/models/generated/account"
@@ -21,9 +21,7 @@ import (
 	"atomys.codes/stud42/internal/models/generated/user"
 	"atomys.codes/stud42/pkg/utils"
 	"entgo.io/ent/dialect/sql"
-	"github.com/bwmarrin/discordgo"
 	"github.com/google/uuid"
-	"github.com/spf13/viper"
 )
 
 func (r *mutationResolver) CreateFriendship(ctx context.Context, userID uuid.UUID) (bool, error) {
@@ -88,19 +86,23 @@ func (r *mutationResolver) InternalLinkAccount(ctx context.Context, input typesg
 		OnConflictColumns(account.FieldProvider, account.FieldProviderAccountID).
 		UpdateNewValues().
 		ID(ctx)
+
 	if err != nil {
 		return nil, err
 	}
 
-	return r.client.Account.Get(ctx, id)
+	account, err := r.client.Account.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	go accountLinkCallback(ctx, account)
+
+	return account, nil
 }
 
 func (r *mutationResolver) InviteOnDiscord(ctx context.Context) (bool, error) {
 	cu, err := CurrentUserFromContext(ctx)
-	if err != nil {
-		return false, err
-	}
-	s, err := discordgo.New("Bot " + os.Getenv("DISCORD_TOKEN"))
 	if err != nil {
 		return false, err
 	}
@@ -110,7 +112,7 @@ func (r *mutationResolver) InviteOnDiscord(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	err = s.GuildMemberAdd(acc.AccessToken, viper.GetString("discord.guildID"), acc.ProviderAccountID, "", []string{}, false, false)
+	err = discord.DefaultClient().InviteOnOurDiscord(ctx, acc.AccessToken, acc.ProviderAccountID)
 	if err != nil {
 		return false, err
 	}

--- a/internal/discord/client.go
+++ b/internal/discord/client.go
@@ -1,0 +1,80 @@
+package discord
+
+import (
+	"errors"
+	"os"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/spf13/viper"
+)
+
+// Client is a wrapper around the discordgo.Session type.
+// It is used to simplify the usage of the discordgo.Session type.
+type Client struct {
+	*discordgo.Session
+}
+
+// defaultClient is the global Discord client used by app who don't want to
+// create their own client.
+var defaultClient *Client
+
+// defaultGuildID returns the Discord guild ID. It will automatically retrieve the
+// guild ID from the environment variable DISCORD_GUILD_ID or from the config
+// file. If no guild ID is set, it will return an error.
+var defaultGuildID string
+
+// ErrNoGuildID is the error returned when no guild ID is set.
+var ErrNoGuildID = errors.New("no guild ID set under viper discord.guildID or env DISCORD_GUILD_ID")
+
+// NewClient creates a new Discord client. It will automatically login to
+// Discord using the Discord token specified in the environment variable
+func NewClient() (*Client, error) {
+	s, err := discordgo.New("Bot " + os.Getenv("DISCORD_TOKEN"))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		Session: s,
+	}, nil
+}
+
+// SetDefaultClient sets the global Discord client used by app who don't want to
+// create their own client.
+func SetDefaultClient(c *Client) {
+	defaultClient = c
+}
+
+// DefaultClient returns the global Discord client used by app who don't want to
+// create their own client. If no client has been set, it will create a new one.
+func DefaultClient() *Client {
+	if defaultClient == nil {
+		defaultClient, _ = NewClient()
+	}
+	return defaultClient
+}
+
+// retrieveGuildID returns the Discord guild ID. It will automatically retrieve the
+// guild ID from the environment variable DISCORD_GUILD_ID or from the config
+// file. If no guild ID is set, it will return an error.
+func retrieveGuildID() string {
+	defaultGuildID = os.Getenv("DISCORD_GUILD_ID")
+	if defaultGuildID == "" {
+		defaultGuildID = viper.GetString("discord.guildID")
+	}
+
+	if defaultGuildID == "" {
+		panic(ErrNoGuildID)
+	}
+	return defaultGuildID
+}
+
+// DefaultGuildID returns the Discord guild ID. It can be used by app who don't want to
+// use complex logic to retrieve the guild ID and only want to manage a single guild.
+func DefaultGuildID() string {
+	if defaultGuildID == "" {
+		defaultGuildID = retrieveGuildID()
+	}
+
+	return defaultGuildID
+}

--- a/internal/discord/utils.go
+++ b/internal/discord/utils.go
@@ -1,0 +1,11 @@
+package discord
+
+import (
+	"context"
+)
+
+// InviteOnOurDiscord invites a user to the S42 server using the Discord API.
+// the discord guild id can be set in the environment variable DISCORD_GUILD_ID.
+func (c *Client) InviteOnOurDiscord(ctx context.Context, token, userID string) error {
+	return c.GuildMemberAdd(token, DefaultGuildID(), userID, "", []string{}, false, false)
+}


### PR DESCRIPTION
**Describe the pull request**

When an user will link github or discord account, no action is taken before expiration on the token, add callbacks to the links to perform followings actions : 
- Link Discord : Invite the user to our Discord 
- Link Github : Star the project / Follow the project (enabled when repo will be public)

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no

**Additional context**

Creation of package for discord client management and utils, will be used in the future discord bot  
