### PR TITLE
chore: change environment variable for oauth due to migration

### DIFF
--- a/deploy/stacks/apps/s42/crawlers.tf
+++ b/deploy/stacks/apps/s42/crawlers.tf
@@ -52,13 +52,11 @@ module "crawler_campus" {
       key  = "POSTGRES_PASSWORD_ENCODED"
       name = "postgres-credentials"
     }
-    # TODO(@42atomys) : Remove this when release
-    FORTY_TWO_CLIENT_ID = {
+    FORTY_TWO_ID = {
       key  = "FORTY_TWO_ID"
       name = "oauth2-providers"
     }
-    # TODO(@42atomys) : Remove this when release
-    FORTY_TWO_CLIENT_SECRET = {
+    FORTY_TWO_SECRET = {
       key  = "FORTY_TWO_SECRET"
       name = "oauth2-providers"
     }
@@ -137,13 +135,11 @@ module "crawler_locations" {
       key  = "POSTGRES_PASSWORD_ENCODED"
       name = "postgres-credentials"
     }
-    # TODO(@42atomys) : Remove this when release
-    FORTY_TWO_CLIENT_ID = {
+    FORTY_TWO_ID = {
       key  = "FORTY_TWO_ID"
       name = "oauth2-providers"
     }
-    # TODO(@42atomys) : Remove this when release
-    FORTY_TWO_CLIENT_SECRET = {
+    FORTY_TWO_SECRET = {
       key  = "FORTY_TWO_SECRET"
       name = "oauth2-providers"
     }

--- a/deploy/stacks/apps/s42/interface.tf
+++ b/deploy/stacks/apps/s42/interface.tf
@@ -71,14 +71,12 @@ module "interface" {
     CONFIG_PATH             = "/config/stud42.yaml"
   }
   envFromSecret = {
-    # TODO(@42atomys) : Remove this when release
-    FORTY_TWO_CLIENT_ID = {
+    FORTY_TWO_ID = {
       key  = "FORTY_TWO_ID"
       name = "oauth2-providers"
     }
 
-    # TODO(@42atomys) : Remove this when release
-    FORTY_TWO_CLIENT_SECRET = {
+    FORTY_TWO_SECRET = {
       key  = "FORTY_TWO_SECRET"
       name = "oauth2-providers"
     }


### PR DESCRIPTION
**Describe the pull request**

To add more clarity to te codebase and oauth2 credentials, I remove the `CLIENT_` from forty-two provider, due to the fact he is the only one to have the `_CLIENT` part on env var naming 

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no