### PR TITLE
fix: certificates overflow on s42.app

### DIFF
--- a/deploy/stacks/cluster/certificates.tf
+++ b/deploy/stacks/cluster/certificates.tf
@@ -58,7 +58,7 @@ module "cert_manager" {
 
   certificates = {
     "app-s42" = {
-      dns_names   = ["s42.app", "*.s42.app"]
+      dns_names   = ["s42.app"]
       issuer_name = "ovh-issuer"
     }
     "app-s42-next" = {


### PR DESCRIPTION
**Describe the pull request**

The certificate of s42.app includes `*.s42.app` and occurs an overflow on top of `dashboards.s42.app` and `next.s42.app`. Usage of wildcard with idle sockets / ssl sockets can occurs a 404 when use two certificates as the same endpoint. 

Remove the wildcard certificate to prevent this error. 

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no