### PR TITLE
feat: reimplement the last connected at based on the location we received 

### DIFF
--- a/api/graphs/api.graphqls
+++ b/api/graphs/api.graphqls
@@ -61,6 +61,7 @@ type User {
   accounts: [Account]
   flags: [FLAG!]!
   currentLocation: Location
+  lastLocation: Location
   currentCampus: Campus
   isFollowing: Boolean!
   isFollower: Boolean!

--- a/internal/api/api.resolvers.go
+++ b/internal/api/api.resolvers.go
@@ -301,12 +301,15 @@ func (r *queryResolver) LocationsStatsByPrefixes(ctx context.Context, campusName
 func (r *queryResolver) MyFollowing(ctx context.Context) ([]*generated.User, error) {
 	cu, _ := CurrentUserFromContext(ctx)
 
+	withCampus := func(lq *generated.LocationQuery) {
+		lq.WithCampus()
+	}
+
 	return r.client.User.Query().
 		Where(user.ID(cu.ID)).
 		QueryFollowing().
-		WithCurrentLocation(func(lq *generated.LocationQuery) {
-			lq.WithCampus()
-		}).
+		WithCurrentLocation(withCampus).
+		WithLastLocation(withCampus).
 		// Unique is necessary because the query builder always add a DISTINCT clause
 		// and cannot order the query properly by location identifier
 		Unique(false).

--- a/internal/models/schema/user.go
+++ b/internal/models/schema/user.go
@@ -40,6 +40,7 @@ func (User) Fields() []ent.Field {
 		field.String("avatar_url").Optional().Nillable().MaxLen(255),
 		field.String("cover_url").Optional().Nillable().MaxLen(255),
 		field.UUID("current_location_id", uuid.UUID{}).Nillable().Optional(),
+		field.UUID("last_location_id", uuid.UUID{}).Nillable().Optional(),
 		field.UUID("current_campus_id", uuid.UUID{}).Nillable().Optional(),
 		field.Bool("is_staff").Default(false),
 		field.Bool("is_a_user").Default(false),
@@ -56,6 +57,10 @@ func (User) Edges() []ent.Edge {
 		edge.To("current_location", Location.Type).
 			Unique().
 			Field("current_location_id").
+			Annotations(entsql.Annotation{OnDelete: entsql.Cascade}),
+		edge.To("last_location", Location.Type).
+			Unique().
+			Field("last_location_id").
 			Annotations(entsql.Annotation{OnDelete: entsql.Cascade}),
 		edge.To("current_campus", Campus.Type).
 			Unique().

--- a/internal/webhooks/location.go
+++ b/internal/webhooks/location.go
@@ -58,7 +58,7 @@ func (p *locationProcessor) Create(loc *duoapi.Location[duoapi.LocationUser], me
 		}
 		// Assign the current location to the user if it's not already assigned
 		// to the user.
-		return tx.User.UpdateOneID(user.ID).SetCurrentLocationID(locationID).SetCurrentCampus(campus).Exec(p.ctx)
+		return tx.User.UpdateOneID(user.ID).SetCurrentLocationID(locationID).SetLastLocationID(locationID).SetCurrentCampus(campus).Exec(p.ctx)
 	})
 
 	return err

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -35,6 +35,7 @@
     "@types/uuid": "^8.3.4",
     "axios": "^0.27.2",
     "classnames": "^2.3.1",
+    "dayjs": "^1.11.6",
     "deepmerge": "^4.2.2",
     "google-protobuf": "^3.20.1-rc.1",
     "graphql": "^16.6.0",

--- a/web/ui/public/assets/favicon/site.webmanifest
+++ b/web/ui/public/assets/favicon/site.webmanifest
@@ -1,19 +1,19 @@
 {
-    "name": "Stud42",
-    "short_name": "Stud42",
-    "icons": [
-        {
-            "src": "/android-chrome-192x192.png",
-            "sizes": "192x192",
-            "type": "image/png"
-        },
-        {
-            "src": "/android-chrome-512x512.png",
-            "sizes": "512x512",
-            "type": "image/png"
-        }
-    ],
-    "theme_color": "#1e293b",
-    "background_color": "#1e293b",
-    "display": "standalone"
+  "name": "Stud42",
+  "short_name": "Stud42",
+  "icons": [
+    {
+      "src": "/assets/favicon/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/assets/favicon/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#1e293b",
+  "background_color": "#1e293b",
+  "display": "standalone"
 }

--- a/web/ui/src/components/ClusterMap/ClusterContainer.tsx
+++ b/web/ui/src/components/ClusterMap/ClusterContainer.tsx
@@ -2,6 +2,7 @@ import Loader from '@components/Loader';
 import useSidebar from '@components/Sidebar';
 import { PopupConsumer, PopupProvider, UserPopup } from '@components/UserPopup';
 import { useClusterViewQuery, User } from '@graphql.d';
+import { isFetchLoading } from '@lib/apollo';
 import { useRouter } from 'next/router';
 import { createContext, useEffect, useState } from 'react';
 import { ClusterSidebar } from '../../containers/clusters/ClusterSidebar';
@@ -51,8 +52,13 @@ export const ClusterContainer: ClusterContainerComponent = ({
     replace,
   } = useRouter();
   const [highlight, setHighlight] = useState(false);
-  const { data, error, loading } = useClusterViewQuery({
+  const { data, error, networkStatus } = useClusterViewQuery({
     variables: { campusName: campus, identifierPrefix: cluster },
+    fetchPolicy: 'network-only',
+    // This is a workaround due to missing websocket implementation.
+    // TODO: Remove this when websocket is implemented.
+    // See https://github.com/42Atomys/stud42/issues/259
+    pollInterval: 1000 * 60, // 1 minute
   });
 
   useEffect(() => {
@@ -90,10 +96,10 @@ export const ClusterContainer: ClusterContainerComponent = ({
                 'p-2 flex-1 flex justify-center min-h-screen items-center'
               }
             >
-              {loading && <Loader />}
+              {isFetchLoading(networkStatus) && <Loader />}
               {error && <div>Error!</div>}
 
-              {!loading && data && (
+              {!isFetchLoading(networkStatus) && data && (
                 <PopupConsumer>
                   {([state, dispatch]) => (
                     <>

--- a/web/ui/src/components/UserPopup/types.d.ts
+++ b/web/ui/src/components/UserPopup/types.d.ts
@@ -4,7 +4,7 @@ import { Location } from '@graphql.d';
 // Represents that state made available via this reducer
 type PopupState = {
   position: DOMRectReadOnly | null;
-  location: Pick<Location, 'identifier'> | null;
+  location: Pick<Location, 'identifier' | 'endAt'> | null;
   user: MapLocation['user'] | null;
 };
 

--- a/web/ui/src/graphql/definitions.gql
+++ b/web/ui/src/graphql/definitions.gql
@@ -141,7 +141,7 @@ query myFollowings {
   myFollowing {
     id
     isFollowing
-    currentLocation {
+    lastLocation {
       ...LocationBasicData
       campus {
         ...CampusBasicData
@@ -185,6 +185,7 @@ query clusterView($campusName: String!, $identifierPrefix: String!) {
       cursor
       node {
         identifier
+        endAt
         user {
           id
           ...UserIdentyData

--- a/web/ui/src/lib/apollo.ts
+++ b/web/ui/src/lib/apollo.ts
@@ -144,6 +144,18 @@ export const isRefetching = (networkStatus: NetworkStatus): boolean => {
 };
 
 /**
+ * Retrieve if the current network status is a first loading event or if
+ * the loading state is due to a page change (or a variable change)
+ * @param networkStatus - the network status of apollo query
+ */
+export const isFetchLoading = (networkStatus: NetworkStatus): boolean => {
+  return (
+    networkStatus === NetworkStatus.loading ||
+    networkStatus === NetworkStatus.setVariables
+  );
+};
+
+/**
  * Check if the current network status is the first loading event or not.
  * Is very usefull to know if we need to show a loading indicator on the UI
  * when a page is loading. And to know if is necessary to show a loading

--- a/web/ui/src/middleware.ts
+++ b/web/ui/src/middleware.ts
@@ -14,8 +14,9 @@ export const middleware: NextMiddleware = async (req) => {
     return NextResponse.next();
   }
 
-  const { data } = await queryAuthenticatedSSR<MeWithFlagsQuery>(req, {
+  const { data, error } = await queryAuthenticatedSSR<MeWithFlagsQuery>(req, {
     query: MeWithFlagsDocument,
+    errorPolicy: 'all',
   });
 
   if (pathname.startsWith('/auth')) {
@@ -23,7 +24,7 @@ export const middleware: NextMiddleware = async (req) => {
     else return NextResponse.next();
   }
 
-  if (!data) {
+  if (!data || error?.message === 'request not authenticated') {
     return NextResponse.redirect(
       new URL(
         '/auth/signin?callbackUrl=' + encodeURIComponent(pathname),

--- a/web/ui/src/pages/friends/index.tsx
+++ b/web/ui/src/pages/friends/index.tsx
@@ -19,7 +19,10 @@ const IndexPage: NextPage<PageProps> = () => {
   const { SidebarProvider, Sidebar, PageContainer, PageContent } = useSidebar();
 
   const [createFriendship] = useCreateFriendshipMutation();
-  const { data, networkStatus, refetch } = useMyFollowingsQuery();
+  const { data, networkStatus, refetch } = useMyFollowingsQuery({
+    fetchPolicy: 'network-only', // Used for first execution
+    nextFetchPolicy: 'cache-and-network', // Used for subsequent executions
+  });
   const { myFollowing } = data || {};
   const hasFollowing = (myFollowing?.length || 0) > 0;
 
@@ -79,7 +82,7 @@ const IndexPage: NextPage<PageProps> = () => {
             <UserCard
               key={user?.duoLogin}
               user={user as User}
-              location={user?.currentLocation}
+              location={user?.lastLocation}
               refetchQueries={[MyFollowingsDocument]}
               className="m-2 hover:scale-[102%] hover:border-indigo-500"
             />

--- a/web/ui/tsconfig.json
+++ b/web/ui/tsconfig.json
@@ -8,6 +8,7 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "module": "esnext",
     "moduleResolution": "node",
     "sourceMap": true,

--- a/web/ui/yarn.lock
+++ b/web/ui/yarn.lock
@@ -4483,6 +4483,11 @@ dayjs@^1.10.4:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.4.tgz#3b3c10ca378140d8917e06ebc13a4922af4f433e"
   integrity sha512-Zj/lPM5hOvQ1Bf7uAvewDaUcsJoI6JmNqmHhHl3nyumwe0XHwt8sWdOVAPACJzCebL8gQCi+K49w7iKWnGwX9g==
 
+dayjs@^1.11.6:
+  version "1.11.6"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.6.tgz#2e79a226314ec3ec904e3ee1dd5a4f5e5b1c7afb"
+  integrity sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ==
+
 debounce@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"


### PR DESCRIPTION
**Relative Issues:** https://discord.com/channels/248936708379246593/1019744956535013436

**Describe the pull request**

On v3, no " offline since" is present. This is a missing feature compared to v2. This PR reimplements the last connected at strategy, but only on the location we already received. This is to prevent any overload call chain on the intranet.

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no

**Additional context**

**Add a new field `lastLocation` to the model user. Can be maybe replace the `currentLocation` relation in the future. This is a duplicated field.**
