### PR TITLE
fix: cluster popup cannot be opened due to nim reference

### DIFF
--- a/web/ui/src/lib/searchEngine.ts
+++ b/web/ui/src/lib/searchEngine.ts
@@ -4,13 +4,16 @@ import { CampusClusterMapData, CampusNames } from '@components/ClusterMap';
  * retrieve the cluster url for the given campus and identifier
  */
 export const clusterURL = (
-  campus: string,
-  identifier: string
+  campus: string | null | undefined,
+  identifier: string | null | undefined
 ): string | null => {
-  const campusLower = campus.toLowerCase();
-  const identifierLower = identifier.toLowerCase();
+  const campusLower = campus?.toLowerCase();
+  const identifierLower = identifier?.toLowerCase();
 
-  if (!Object.keys(CampusClusterMapData).includes(campusLower)) {
+  if (
+    !campusLower ||
+    !Object.keys(CampusClusterMapData).includes(campusLower)
+  ) {
     return null;
   }
 


### PR DESCRIPTION
**Describe the pull request**

Due to 0.17 deployment and changes applied to popup and new `lastConnectedAt`, the popup component cannot be mounted due to search-engine nil reference

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no