### PR TITLE
fix: loader on friends page is displayed when data is already loaded

### DIFF
--- a/web/ui/src/pages/friends/index.tsx
+++ b/web/ui/src/pages/friends/index.tsx
@@ -78,15 +78,16 @@ const IndexPage: NextPage<PageProps> = () => {
               </span>
             </div>
           )}
-          {myFollowing?.map((user) => (
-            <UserCard
-              key={user?.duoLogin}
-              user={user as User}
-              location={user?.lastLocation}
-              refetchQueries={[MyFollowingsDocument]}
-              className="m-2 hover:scale-[102%] hover:border-indigo-500"
-            />
-          ))}
+          {!isFirstLoading(networkStatus) &&
+            myFollowing?.map((user) => (
+              <UserCard
+                key={user?.duoLogin}
+                user={user as User}
+                location={user?.lastLocation}
+                refetchQueries={[MyFollowingsDocument]}
+                className="m-2 hover:scale-[102%] hover:border-indigo-500"
+              />
+            ))}
         </PageContent>
       </PageContainer>
     </SidebarProvider>


### PR DESCRIPTION
**Describe the pull request**

The loader on friends page is displayed when the data is already loaded and cause blink effect.

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no