### PR TITLE
fix: user already present on database cant link account to her user

### DIFF
--- a/web/ui/src/pages/api/auth/[...nextauth].ts
+++ b/web/ui/src/pages/api/auth/[...nextauth].ts
@@ -16,6 +16,13 @@ export default NextAuth({
     FortyTwoProvider({
       clientId: process.env.FORTY_TWO_ID as string,
       clientSecret: process.env.FORTY_TWO_SECRET as string,
+      // allowDangerousEmailAccountLinking
+      // https://next-auth.js.org/configuration/providers/oauth#allowdangerousemailaccountlinking-option
+      //
+      // We allow email linking to the account due to the fact of 42 email are
+      // unique and not editable by the user. The user is already present on database
+      // when he be connected on cluster before.
+      allowDangerousEmailAccountLinking: true,
     }),
     GithubProvider({
       clientId: process.env.GITHUB_ID as string,


### PR DESCRIPTION
**Relative Issues:** Resolve #271 

**Describe the pull request**

Due to the fact of user is pre-loaded in database when he connect in a campus, an user cannot link her account correctly and be stuck in the login page

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no