### PR TITLE
fix: github sponsors has kicked out when cancel a sponsorship

### DIFF
--- a/internal/webhooks/serve.go
+++ b/internal/webhooks/serve.go
@@ -196,17 +196,9 @@ func (p *processor) githubHandler(data []byte) error {
 	var flagsList = user.FlagsList
 	switch webhookPayload.Action {
 	case "created", "edited":
-		if webhookPayload.Sponsorship.Tier.MonthlyPriceInDollars >= 5 {
-			flagsList = append(flagsList, typesgen.FlagBeta.String(), typesgen.FlagDiscord.String())
-		}
 		flagsList = append(flagsList, typesgen.FlagSponsor.String())
 	case "cancelled":
-		flagsList = utils.Remove(
-			flagsList,
-			typesgen.FlagSponsor.String(),
-			typesgen.FlagBeta.String(),
-			typesgen.FlagDiscord.String(),
-		)
+		flagsList = utils.Remove(flagsList, typesgen.FlagSponsor.String())
 	}
 
 	_, err = p.db.User.UpdateOne(user).SetFlagsList(utils.Uniq(flagsList)).Save(p.ctx)


### PR DESCRIPTION
**Relative Issues:** https://discord.com/channels/248936708379246593/954510970586284082/1046399942215872572

**Describe the pull request**

When a github sponsors cancel her sponsorship, the webhook processor kick the user outside of the beta. With open beta, nobody needs to be kicked out.

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no