### PR TITLE
chore: remove discord release message embeds

### DIFF
--- a/.github/workflows/discord-push-release.yaml
+++ b/.github/workflows/discord-push-release.yaml
@@ -24,6 +24,7 @@ jobs:
             {
               "content": ${{ toJSON(fromJSON(env.GITHUB_CONTEXT).event.release.body) }},
               "tts": false,
+              "flags": 100,
               "components": [
                 {
                   "type": 1,


### PR DESCRIPTION
**Describe the pull request**

Since the repository is public, the release message includes embeds. Add a flag to automatically remove all embeds.

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no