### PR TITLE
fix: the user is not correctly considered as active

### DIFF
--- a/internal/api/account_callbacks.go
+++ b/internal/api/account_callbacks.go
@@ -59,7 +59,7 @@ func duoLinkCallback(ctx context.Context, db *modelgen.Client, account *modelgen
 }
 
 // discordLinkCallback is the callback for Discord accounts when the account is
-// linked to a user. It will add the user to the Discord server.
+// linked to an user. It will add the user to the Discord server.
 func discordLinkCallback(ctx context.Context, db *modelgen.Client, account *modelgen.Account) {
 	// Invite the user to the S42 server using the Discord API
 	err := discord.
@@ -71,7 +71,7 @@ func discordLinkCallback(ctx context.Context, db *modelgen.Client, account *mode
 }
 
 // githubLinkCallback is the callback for Github accounts when the account is
-// linked to a user. It will follow the creator of the repository and star
+// linked to an user. It will follow the creator of the repository and star
 // the repository.
 func githubLinkCallback(ctx context.Context, db *modelgen.Client, account *modelgen.Account) {
 	client := github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(


### PR DESCRIPTION
**Relative Issues:** Resolve #279 

**Describe the pull request**
One column on the model user called `is_a_user` must be set as true when an User takes the action to join the app. But actually, the number of active users seems to lower. This PR fix this issue

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no

**Additional context**
A manual migration in the database will be perfromed to set all user with duo account linked as active.
