### PR TITLE
fix: operations reindex users reach max meilisearch connection

### DIFF
--- a/cmd/reindexusers.go
+++ b/cmd/reindexusers.go
@@ -45,7 +45,10 @@ all the users.`,
 		}
 
 		// Re-index all the users
-		batchSize := 1000
+		batchSize, err := strconv.Atoi(cmd.Flag("batch_size").Value.String())
+		if err != nil || batchSize < 1 {
+			log.Fatal().Err(err).Msg("Cannot cast batch_size flag. batch_size msut be a positive integer")
+		}
 		usersCount := modelsutils.Client().User.Query().CountX(cmd.Context())
 		log.Info().
 			Int("usersCount", usersCount).
@@ -87,4 +90,6 @@ all the users.`,
 
 func init() {
 	operationsCmd.AddCommand(reindexusersCmd)
+	
+	operationsCmd.Flags().StringP("batch_size", "b", "50", "Batch size of the reindex")
 }

--- a/cmd/reindexusers.go
+++ b/cmd/reindexusers.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"math"
+	"strconv"
 	"sync"
 
 	modelsutils "atomys.codes/stud42/internal/models"

--- a/cmd/reindexusers.go
+++ b/cmd/reindexusers.go
@@ -32,7 +32,7 @@ all the users.`,
 		searchengine.Initizialize()
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Info().Msg("Start the re-indexation of the users")
+		log.Info().Msg("Prepare the re-indexation of the users")
 
 		meiliClient := searchengine.NewClient()
 
@@ -53,6 +53,7 @@ all the users.`,
 		usersCount := modelsutils.Client().User.Query().CountX(cmd.Context())
 		log.Info().
 			Int("usersCount", usersCount).
+			Int("batchSize", batchSize).
 			Float64("batchCount", math.Ceil(float64(usersCount)/float64(batchSize))).
 			Msg("Start the re-indexation of the users")
 
@@ -91,6 +92,6 @@ all the users.`,
 
 func init() {
 	operationsCmd.AddCommand(reindexusersCmd)
-	
-	operationsCmd.Flags().StringP("batch_size", "b", "50", "Batch size of the reindex")
+
+	operationsCmd.PersistentFlags().IntP("batch_size", "b", 50, "Batch size of the reindex")
 }


### PR DESCRIPTION
**Relative Issues:** Resolve #296 

**Describe the pull request**

The reindex user operation cannot be run in production due to users count

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**

no
