### PR TITLE
fix: search engine order is not relevant

### DIFF
--- a/cmd/reindexusers.go
+++ b/cmd/reindexusers.go
@@ -8,6 +8,7 @@ import (
 	modelsutils "atomys.codes/stud42/internal/models"
 	modelgen "atomys.codes/stud42/internal/models/generated"
 	"atomys.codes/stud42/internal/pkg/searchengine"
+	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
@@ -51,16 +52,17 @@ all the users.`,
 			log.Fatal().Err(err).Msg("Cannot cast batch_size flag. batch_size msut be a positive integer")
 		}
 		usersCount := modelsutils.Client().User.Query().CountX(cmd.Context())
+		batchCount := int(math.Ceil(float64(usersCount) / float64(batchSize)))
 		log.Info().
 			Int("usersCount", usersCount).
 			Int("batchSize", batchSize).
-			Float64("batchCount", math.Ceil(float64(usersCount)/float64(batchSize))).
+			Int("batchCount", batchCount).
 			Msg("Start the re-indexation of the users")
 
-		for i := 0; i < usersCount; i += batchSize {
-			users := modelsutils.Client().User.Query().Offset(i).Limit(batchSize).AllX(cmd.Context())
+		for i := 0; i*batchSize < usersCount; i += 1 {
+			users := modelsutils.Client().User.Query().Offset(i * batchSize).Limit(batchSize).AllX(cmd.Context())
 
-			log.Info().Int("batchId", i).Int("usersCount", len(users)).Msg("Reindexing users in batch")
+			log.Info().Int("batch", i+1).Int("batchCount", batchCount).Int("usersCount", len(users)).Msg("Reindexing users in batch")
 
 			var wg sync.WaitGroup
 			for _, user := range users {
@@ -75,6 +77,7 @@ all the users.`,
 						FirstName:       user.FirstName,
 						UsualFirstName:  user.UsualFirstName,
 						LastName:        user.LastName,
+						HasOnline:       user.CurrentLocationID != nil && *user.CurrentLocationID != uuid.Nil,
 					}
 
 					if err := meiliClient.UpdateUserDocument(cmd.Context(), document); err != nil {

--- a/cmd/reindexusers.go
+++ b/cmd/reindexusers.go
@@ -70,6 +70,7 @@ all the users.`,
 				go func(user *modelgen.User) {
 					defer wg.Done()
 
+					hasOnline := user.CurrentLocationID != nil && *user.CurrentLocationID != uuid.Nil
 					document := &searchengine.UserDocument{
 						ID:              user.ID,
 						CurrentCampusID: user.CurrentCampusID,
@@ -77,7 +78,7 @@ all the users.`,
 						FirstName:       user.FirstName,
 						UsualFirstName:  user.UsualFirstName,
 						LastName:        user.LastName,
-						HasOnline:       user.CurrentLocationID != nil && *user.CurrentLocationID != uuid.Nil,
+						HasOnline:       &hasOnline,
 					}
 
 					if err := meiliClient.UpdateUserDocument(cmd.Context(), document); err != nil {

--- a/internal/models/schema/user.go
+++ b/internal/models/schema/user.go
@@ -119,6 +119,7 @@ func meilisearchUpdateHook(next ent.Mutator) ent.Mutator {
 			LastName() (lastName string, exists bool)
 			DuoLogin() (duoLogin string, exists bool)
 			CurrentCampusID() (currentCampusID uuid.UUID, exists bool)
+			CurrentLocationID() (currentLocationID uuid.UUID, exists bool)
 		})
 		if !ok {
 			log.Error().Err(err).Msg("cannot update MeiliSearch index: mutation is not a User")
@@ -161,6 +162,10 @@ func meilisearchUpdateHook(next ent.Mutator) ent.Mutator {
 
 		if currentCampusID, ok := userMutation.CurrentCampusID(); ok {
 			document.CurrentCampusID = &currentCampusID
+		}
+
+		if currentLocationID, ok := userMutation.CurrentLocationID(); ok {
+			document.HasOnline = currentLocationID != uuid.Nil
 		}
 
 		// Update the index.

--- a/internal/models/schema/user.go
+++ b/internal/models/schema/user.go
@@ -120,6 +120,8 @@ func meilisearchUpdateHook(next ent.Mutator) ent.Mutator {
 			DuoLogin() (duoLogin string, exists bool)
 			CurrentCampusID() (currentCampusID uuid.UUID, exists bool)
 			CurrentLocationID() (currentLocationID uuid.UUID, exists bool)
+			CurrentLocationIDCleared() bool
+			CurrentLocationCleared() bool
 		})
 		if !ok {
 			log.Error().Err(err).Msg("cannot update MeiliSearch index: mutation is not a User")
@@ -164,8 +166,11 @@ func meilisearchUpdateHook(next ent.Mutator) ent.Mutator {
 			document.CurrentCampusID = &currentCampusID
 		}
 
-		if currentLocationID, ok := userMutation.CurrentLocationID(); ok {
-			document.HasOnline = currentLocationID != uuid.Nil
+		if currentLocationID, ok := userMutation.CurrentLocationID(); ok ||
+			userMutation.CurrentLocationIDCleared() ||
+			userMutation.CurrentLocationCleared() {
+			hasOnline := currentLocationID != uuid.Nil
+			document.HasOnline = &hasOnline
 		}
 
 		// Update the index.

--- a/internal/pkg/searchengine/meilisearch.go
+++ b/internal/pkg/searchengine/meilisearch.go
@@ -3,7 +3,6 @@ package searchengine
 import (
 	"fmt"
 
-	"github.com/google/uuid"
 	"github.com/meilisearch/meilisearch-go"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
@@ -48,24 +47,4 @@ func (c *Client) EnsureAllIndexes() error {
 		return fmt.Errorf("failed to ensure user index: %w", err)
 	}
 	return nil
-}
-
-// SearchUser searches for a user in the MeiliSearch index.
-// It returns a slice of UUIDs of the users found.
-func (c *Client) SearchUser(query string) ([]uuid.UUID, error) {
-	results, err := c.Client.Index(IndexUser).Search(query,
-		&meilisearch.SearchRequest{
-			Limit: 10,
-		})
-
-	if err != nil {
-		return nil, err
-	}
-
-	var usersIDs []uuid.UUID
-
-	for _, res := range results.Hits {
-		usersIDs = append(usersIDs, uuid.MustParse(fmt.Sprint(res.(map[string]interface{})["id"])))
-	}
-	return usersIDs, nil
 }

--- a/internal/pkg/searchengine/meilisearch_user_index.go
+++ b/internal/pkg/searchengine/meilisearch_user_index.go
@@ -13,7 +13,7 @@ import (
 type UserDocument struct {
 	ID              uuid.UUID  `json:"id"`
 	CurrentCampusID *uuid.UUID `json:"current_campus_id,omitempty"`
-	HasOnline       bool       `json:"has_online,omitempty"`
+	HasOnline       *bool      `json:"has_online,omitempty"`
 	DuoLogin        string     `json:"duo_login,omitempty"`
 	FirstName       string     `json:"first_name,omitempty"`
 	UsualFirstName  *string    `json:"usual_first_name,omitempty"`
@@ -56,7 +56,7 @@ func (c *Client) EnsureUserIndex() error {
 		// Only display the user id in the search results to avoid leaking information
 		// about the user.
 		DisplayedAttributes:  []string{IndexUserPrimaryKey},
-		FilterableAttributes: []string{"current_location_id", "current_campus_id"},
+		FilterableAttributes: []string{"has_online", "current_campus_id"},
 	})
 	if err != nil {
 		return err

--- a/internal/pkg/searchengine/meilisearch_user_index.go
+++ b/internal/pkg/searchengine/meilisearch_user_index.go
@@ -2,6 +2,7 @@ package searchengine
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/meilisearch/meilisearch-go"
@@ -12,6 +13,7 @@ import (
 type UserDocument struct {
 	ID              uuid.UUID  `json:"id"`
 	CurrentCampusID *uuid.UUID `json:"current_campus_id,omitempty"`
+	HasOnline       bool       `json:"has_online,omitempty"`
 	DuoLogin        string     `json:"duo_login,omitempty"`
 	FirstName       string     `json:"first_name,omitempty"`
 	UsualFirstName  *string    `json:"usual_first_name,omitempty"`
@@ -53,12 +55,38 @@ func (c *Client) EnsureUserIndex() error {
 		SearchableAttributes: []string{"duo_login", "first_name", "last_name", "usual_first_name"},
 		// Only display the user id in the search results to avoid leaking information
 		// about the user.
-		DisplayedAttributes: []string{IndexUserPrimaryKey},
+		DisplayedAttributes:  []string{IndexUserPrimaryKey},
+		FilterableAttributes: []string{"current_location_id", "current_campus_id"},
 	})
 	if err != nil {
 		return err
 	}
 	return nil
+}
+
+// SearchUser searches for a user in the MeiliSearch index.
+// It returns a slice of UUIDs of the users found.
+func (c *Client) SearchUser(query string, onlyOnline bool) ([]uuid.UUID, error) {
+	req := &meilisearch.SearchRequest{
+		Limit: 10,
+	}
+
+	if onlyOnline {
+		req.Filter = "current_location_id != null"
+	}
+
+	results, err := c.Client.Index(IndexUser).Search(query, req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var usersIDs []uuid.UUID
+
+	for _, res := range results.Hits {
+		usersIDs = append(usersIDs, uuid.MustParse(fmt.Sprint(res.(map[string]interface{})["id"])))
+	}
+	return usersIDs, nil
 }
 
 // UpdateUserDocument updates the MeiliSearch document for the given user. It

--- a/pkg/utils/slice.go
+++ b/pkg/utils/slice.go
@@ -1,5 +1,7 @@
 package utils
 
+import "fmt"
+
 // Remove an item from a slice
 func Remove[T comparable](slice []T, items ...T) []T {
 	var result = make([]T, 0)
@@ -33,4 +35,13 @@ func Uniq[T comparable](slice []T) []T {
 		unique = append(unique, element)
 	}
 	return unique
+}
+
+// StringifySlice transform a slice of Stringer into a slice of string
+func StringifySlice[T fmt.Stringer](slice []T) []string {
+	strSlice := make([]string, len(slice))
+	for i, element := range slice {
+		strSlice[i] = element.String()
+	}
+	return strSlice
 }

--- a/pkg/utils/slice_test.go
+++ b/pkg/utils/slice_test.go
@@ -3,15 +3,16 @@ package utils
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRemove(t *testing.T) {
 	tests := []struct {
-		name string
-		sliceBase []string
+		name          string
+		sliceBase     []string
 		itemsToRemove []string
-		want []string
+		want          []string
 	}{
 		{"remove one item", []string{"a", "b", "c"}, []string{"b"}, []string{"a", "c"}},
 		{"remove multiple items", []string{"a", "b", "c"}, []string{"b", "c"}, []string{"a"}},
@@ -23,13 +24,12 @@ func TestRemove(t *testing.T) {
 	}
 }
 
-
 func TestContains(t *testing.T) {
 	tests := []struct {
-		name string
+		name      string
 		sliceBase []string
-		item string
-		want bool
+		item      string
+		want      bool
 	}{
 		{"contains one item", []string{"a", "b", "c"}, "b", true},
 		{"contains multiple items", []string{"a", "b", "c"}, "b", true},
@@ -43,9 +43,9 @@ func TestContains(t *testing.T) {
 
 func TestUniq(t *testing.T) {
 	tests := []struct {
-		name string
+		name      string
 		sliceBase []string
-		want []string
+		want      []string
 	}{
 		{"uniq one item", []string{"a", "b", "c"}, []string{"a", "b", "c"}},
 		{"uniq multiple items", []string{"a", "b", "c", "a", "b", "c"}, []string{"a", "b", "c"}},
@@ -55,4 +55,10 @@ func TestUniq(t *testing.T) {
 	for _, tt := range tests {
 		assert.Equal(t, tt.want, Uniq(tt.sliceBase), tt.name)
 	}
+}
+
+func TestStringifySlice(t *testing.T) {
+	uuidTest := uuid.New()
+
+	assert.Equal(t, []string{uuidTest.String()}, StringifySlice([]uuid.UUID{uuidTest}))
 }


### PR DESCRIPTION
**Relative Issues:** Resolve #300 

**Describe the pull request**

With the new search engine deployed in 0.19, the global system works correctly but the final ordering don’t match with the query.

This is due to the usage of IN() sql statement, how don’t keep the order in the result set.

**Checklist**

- [ ] I have linked the relative issue to this pull request
- [ ] I have made the modifications or added tests related to my PR
- [ ] I have added/updated the documentation for my RP
- [ ] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no
