### PR TITLE
fix: locations badge on friends page crash due to invalid location

### DIFF
--- a/web/ui/src/components/Badge/LocationBadge.tsx
+++ b/web/ui/src/components/Badge/LocationBadge.tsx
@@ -30,14 +30,10 @@ export const LocationBadge = ({
           location?.identifier as string
         );
         if (!url) {
-          return <></>;
+          return <>{children}</>;
         }
 
-        return (
-          <Link href={url}>
-            <a>{children}</a>
-          </Link>
-        );
+        return <Link href={url}>{children}</Link>;
       }}
       falseWrapper={(children) => {
         return dayJsObject ? (
@@ -53,14 +49,14 @@ export const LocationBadge = ({
         );
       }}
     >
-      <Badge color={isConnected ? 'green' : 'gray'}>
+      <Badge color={isConnected ? 'green' : 'gray'} className="max-w-full">
         <span
           className={classNames(
             'inline-flex rounded-full w-2 h-2',
             isConnected ? 'bg-emerald-500' : 'bg-slate-500'
           )}
         ></span>
-        <span className="flex flex-row justify-center items-center text-sm mx-1">
+        <span className="text-sm mx-1 flex-1 truncate">
           {isConnected
             ? location?.identifier
             : dayJsObject?.fromNow() || 'offline'}

--- a/web/ui/src/lib/clustersMap/campus.ts
+++ b/web/ui/src/lib/clustersMap/campus.ts
@@ -1,10 +1,41 @@
-import { ICampus, ICluster } from './types';
+import { CampusNames, ICampus, ICluster } from './types';
 
 /**
  * Campus class represents a campus in the cluster map. It contains the
  * campus name, emoji, extractor function, and the list of clusters.
  */
-export class Campus implements Pick<ICampus, 'clusters'> {
+export class Campus implements ICampus {
+  emoji(): string {
+    throw new Error('Method not implemented.');
+  }
+
+  name(): CampusNames {
+    throw new Error('Method not implemented.');
+  }
+
+  extractorRegexp(): RegExp {
+    throw new Error('Method not implemented.');
+  }
+
+  extractor(identifier: string) {
+    const result = this.extractorRegexp().exec(identifier);
+    if (!result || !result.groups) {
+      const err = new Error(
+        `Invalid identifier for ${this.name()}: ${identifier}. Expected format: c1r2p3`
+      );
+      return {
+        cluster: err.message,
+        row: err.message,
+        workspace: err.message,
+        clusterWithLetter: err.message,
+        rowWithLetter: err.message,
+        workspaceWithLetter: err.message,
+      };
+    }
+
+    return result.groups as ReturnType<ICampus['extractor']>;
+  }
+
   /**
    * List of clusters for this campus
    */

--- a/web/ui/src/lib/clustersMap/campus/helsinki.ts
+++ b/web/ui/src/lib/clustersMap/campus/helsinki.ts
@@ -8,19 +8,8 @@ export class Helsinki extends Campus implements ICampus {
 
   name = (): CampusNames => 'helsinki';
 
-  extractor = (identifier: string) => {
-    const regex =
-      /(?<clusterWithLetter>c(?<cluster>\d+))(?<rowWithLetter>r(?<row>\d+))(?<workspaceWithLetter>p(?<workspace>\d+))/i;
-
-    const result = regex.exec(identifier);
-    if (!result || !result.groups) {
-      throw new Error(
-        `Invalid identifier: ${identifier}. Expected format: c1r2p3`
-      );
-    }
-
-    return result.groups as ReturnType<ICampus['extractor']>;
-  };
+  extractorRegexp = (): RegExp =>
+    /(?<clusterWithLetter>c(?<cluster>\d+))(?<rowWithLetter>r(?<row>\d+))(?<workspaceWithLetter>p(?<workspace>\d+))/i;
 
   clusters(): Cluster[] {
     return [

--- a/web/ui/src/lib/clustersMap/campus/malaga.ts
+++ b/web/ui/src/lib/clustersMap/campus/malaga.ts
@@ -8,19 +8,8 @@ export class Malaga extends Campus implements ICampus {
 
   name = (): CampusNames => 'malaga';
 
-  extractor = (identifier: string) => {
-    const regex =
-      /(?<clusterWithLetter>c(?<cluster>\d+))(?<rowWithLetter>r(?<row>\d+))(?<workspaceWithLetter>p(?<workspace>\d+))/i;
-
-    const result = regex.exec(identifier);
-    if (!result || !result.groups) {
-      throw new Error(
-        `Invalid identifier: ${identifier}. Expected format: c1r2p3`
-      );
-    }
-
-    return result.groups as ReturnType<ICampus['extractor']>;
-  };
+  extractorRegexp = (): RegExp =>
+    /(?<clusterWithLetter>c(?<cluster>\d+))(?<rowWithLetter>r(?<row>\d+))(?<workspaceWithLetter>p(?<workspace>\d+))/i;
 
   clusters(): Cluster[] {
     return [

--- a/web/ui/src/lib/clustersMap/campus/paris.ts
+++ b/web/ui/src/lib/clustersMap/campus/paris.ts
@@ -8,19 +8,8 @@ export class Paris extends Campus implements ICampus {
 
   name = (): CampusNames => 'paris';
 
-  extractor = (identifier: string) => {
-    const regex =
-      /(?<clusterWithLetter>e(?<cluster>\d+))(?<rowWithLetter>r(?<row>\d+))(?<workspaceWithLetter>p(?<workspace>\d+))/i;
-
-    const result = regex.exec(identifier);
-    if (!result || !result.groups) {
-      throw new Error(
-        `Invalid identifier: ${identifier}. Expected format: e1r2p3`
-      );
-    }
-
-    return result.groups as ReturnType<ICampus['extractor']>;
-  };
+  extractorRegexp = (): RegExp =>
+    /(?<clusterWithLetter>e(?<cluster>\d+))(?<rowWithLetter>r(?<row>\d+))(?<workspaceWithLetter>p(?<workspace>\d+))/i;
 
   clusters(): Cluster[] {
     return [

--- a/web/ui/src/lib/clustersMap/campus/vienna.ts
+++ b/web/ui/src/lib/clustersMap/campus/vienna.ts
@@ -8,19 +8,8 @@ export class Vienna extends Campus implements ICampus {
 
   name = (): CampusNames => 'vienna';
 
-  extractor = (identifier: string) => {
-    const regex =
-      /(?<clusterWithLetter>c(?<cluster>\d+))(?<rowWithLetter>r(?<row>\d+))(?<workspaceWithLetter>p(?<workspace>\d+))/i;
-
-    const result = regex.exec(identifier);
-    if (!result || !result.groups) {
-      throw new Error(
-        `Invalid identifier: ${identifier}. Expected format: c1r2p3`
-      );
-    }
-
-    return result.groups as ReturnType<ICampus['extractor']>;
-  };
+  extractorRegexp = (): RegExp =>
+    /(?<clusterWithLetter>c(?<cluster>\d+))(?<rowWithLetter>r(?<row>\d+))(?<workspaceWithLetter>p(?<workspace>\d+))/i;
 
   clusters(): Cluster[] {
     return [

--- a/web/ui/src/lib/clustersMap/types.d.ts
+++ b/web/ui/src/lib/clustersMap/types.d.ts
@@ -65,6 +65,10 @@ export interface ICampus {
     workspaceWithLetter: string;
   };
 
+  // extractorRegexp contain a regexp to extract data from identifier used on
+  // extractor function. See extractor function for more details.
+  extractorRegexp(): RegExp;
+
   // List of clusters for this campus
   clusters(): ICluster[];
 


### PR DESCRIPTION
**Relative Issues:** https://discord.com/channels/248936708379246593/1049339339441705010

**Describe the pull request**

Due to recent update, the identifier extractor will crash on bocal locations.

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no