### PR TITLE
fix: meilisearch tasks is not cleaned and increase the volume size

### DIFF
--- a/deploy/stacks/apps/s42/meilisearch.tf
+++ b/deploy/stacks/apps/s42/meilisearch.tf
@@ -95,18 +95,21 @@ module "meilisearch_clean_tasks" {
 
   jobSchedule                = "0 0 * * *" # Every day at the midnight
   jobTTLSecondsAfterFinished = 0
+  restartPolicy              = "OnFailure"
 
+  name       = "meilisearch-clean-tasks"
   appName    = "meilisearch-clean-tasks"
   appVersion = local.meilisearchVersion
   namespace  = var.namespace
   image      = "curlimages/curl:7.86.0"
 
   args = [
+    "--fail",
     "-X",
     "DELETE",
     "http://meilisearch:7700/tasks?statuses=failed,canceled,succeeded",
     "-H",
-    "Authorization: Bearer $MEILI_MASTER_KEY",
+    "Authorization: Bearer $(MEILI_MASTER_KEY)",
     "-H",
     "Content-Type: application/json"
   ]

--- a/deploy/stacks/apps/s42/meilisearch.tf
+++ b/deploy/stacks/apps/s42/meilisearch.tf
@@ -1,3 +1,7 @@
+locals {
+  meilisearchVersion = "v0.30"
+}
+
 resource "random_password" "meilisearch_token" {
   length  = 64
   special = true
@@ -8,9 +12,9 @@ module "meilisearch" {
 
   name       = "meilisearch"
   appName    = "meilisearch"
-  appVersion = "v0.30"
+  appVersion = local.meilisearchVersion
   namespace  = var.namespace
-  image      = "getmeili/meilisearch:v0.30"
+  image      = "getmeili/meilisearch:${local.meilisearchVersion}"
 
   nodeSelector = local.nodepoolSelector["services"]
 
@@ -81,6 +85,38 @@ module "meilisearch" {
       data = {
         "MEILI_MASTER_KEY" = random_password.meilisearch_token.result
       }
+    }
+  }
+}
+
+module "meilisearch_clean_tasks" {
+  source = "../../../modules/service"
+  kind   = "CronJob"
+
+  jobSchedule                = "0 0 * * *" # Every day at the midnight
+  jobTTLSecondsAfterFinished = 0
+
+  appName    = "meilisearch-clean-tasks"
+  appVersion = local.meilisearchVersion
+  namespace  = var.namespace
+  image      = "curlimages/curl:7.86.0"
+
+  args = [
+    "-X",
+    "DELETE",
+    "http://meilisearch:7700/tasks?statuses=failed,canceled,succeeded",
+    "-H",
+    "Authorization: Bearer $MEILI_MASTER_KEY",
+    "-H",
+    "Content-Type: application/json"
+  ]
+
+  nodeSelector = local.nodepoolSelector["services"]
+
+  envFromSecret = {
+    MEILI_MASTER_KEY = {
+      key  = "MEILI_MASTER_KEY"
+      name = "meilisearch-token"
     }
   }
 }

--- a/deploy/stacks/apps/s42/meilisearch.tf
+++ b/deploy/stacks/apps/s42/meilisearch.tf
@@ -9,6 +9,7 @@ resource "random_password" "meilisearch_token" {
 
 module "meilisearch" {
   source = "../../../modules/service"
+  kind   = "StatefulSet"
 
   name       = "meilisearch"
   appName    = "meilisearch"


### PR DESCRIPTION
**Relative Issues:** Resolve #356 

**Describe the pull request**

Meilsiearch create a task for each async action. When we perform an update of an object in meilisearch, MS create a task. In 1 week we create million of tasks and that is never cleaned. This PR implement a cronjob who delete old tasks to keep volume clean and small as possible. 

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no