### PR TITLE
fix: time in the past on badge tests to prevent false errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ internal/models/generated/*
 internal/models/structs_generated.go
 internal/**/*.pb.go
 
+# testing
+coverage.out
+
 # =================================================
 # Frontned ignores 🕹
 # =================================================

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -127,6 +127,61 @@
       "problemMatcher": ["$tsc"]
     },
     {
+      "label": "Test Interface",
+      "detail": "Run the test suite on the Interface (CI Mode)",
+      "type": "shell",
+      "command": "yarn",
+      "args": ["--cwd", "web/ui", "test:ci"],
+      "icon": {
+        "id": "beaker",
+        "color": "terminal.ansiBlue"
+      },
+      "presentation": {
+        "focus": true,
+        "panel": "dedicated"
+      },
+      "problemMatcher": ["$tsc"]
+    },
+    {
+      "label": "Test Interface",
+      "detail": "Run the test suite on the Interface (Watch Mode)",
+      "type": "shell",
+      "command": "yarn",
+      "args": ["--cwd", "web/ui", "test"],
+      "icon": {
+        "id": "beaker",
+        "color": "terminal.ansiBlue"
+      },
+      "presentation": {
+        "focus": true,
+        "panel": "dedicated"
+      },
+      "problemMatcher": ["$tsc"]
+    },
+    {
+      "label": "Test API",
+      "detail": "Run the test suite on the backend",
+      "type": "shell",
+      "command": "go",
+      "args": [
+        "test",
+        "./...",
+        "-coverprofile",
+        "coverage.out",
+        "-covermode",
+        "count"
+      ],
+      "icon": {
+        "id": "beaker",
+        "color": "terminal.ansiBlue"
+      },
+      "presentation": {
+        "focus": true,
+        "panel": "dedicated"
+      },
+      "problemMatcher": ["$tsc"]
+    },
+    {
       "label": "Run postgresql cli (psql)",
       "detail": "Execute psql on container",
       "type": "process",

--- a/build/install-dependencies.sh
+++ b/build/install-dependencies.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 
+echo "Installing dependencies..."
+echo "Installing protoc for $(uname -s) $(uname -m) ..."
+
 OS=$(([ "$(uname -s)" == 'Darwin' ] && echo "osx" || echo "$(uname -s)") | tr '[:upper:]' '[:lower:]')
 URL=$(curl -s https://api.github.com/repos/protocolbuffers/protobuf/releases/latest | \
-  jq -c ".assets | map(select( .name | contains(\"protoc\") and contains(\"$(uname -m)\") and contains(\"$OS\"))) | .[].browser_download_url" | \
+  jq -c "try .assets | map(select( .name | contains(\"protoc\") and contains(\"$(uname -m)\") and contains(\"$OS\"))) | .[].browser_download_url" | \
   tr -d \")
 
 if [ -z "$URL" ]; then
   echo "Could not find protoc binary for your platform. Fallback to linux"
   URL=$(curl -s https://api.github.com/repos/protocolbuffers/protobuf/releases/latest | \
-    jq -c ".assets | map(select( .name | contains(\"protoc\") and contains(\"x86_64\") and contains(\"linux\"))) | .[].browser_download_url" | \
+    jq -c "try .assets | map(select( .name | contains(\"protoc\") and contains(\"x86_64\") and contains(\"linux\"))) | .[].browser_download_url" | \
     tr -d \") 
 fi
 

--- a/web/ui/src/components/Badge/__tests__/LocationBadge.test.tsx
+++ b/web/ui/src/components/Badge/__tests__/LocationBadge.test.tsx
@@ -2,7 +2,7 @@ import { LocationBadge } from '@components/Badge';
 import { render } from '@testing-library/react';
 
 const validLocation = {
-  beginAt: '2022-10-10T00:00:00Z',
+  beginAt: '2022-10-25T00:00:00Z',
   endAt: null,
   identifier: 'e1r4p21',
   campus: {
@@ -12,6 +12,9 @@ const validLocation = {
 };
 
 describe('snapshots', () => {
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2022-12-25T00:00:00Z'));
+  });
   it('renders LocationBadge unchanged', () => {
     const { container } = render(<LocationBadge location={null} />);
     expect(container).toMatchSnapshot();
@@ -19,7 +22,7 @@ describe('snapshots', () => {
 
   it('renders LocationBadge with offline location unchanged', () => {
     const { container } = render(
-      <LocationBadge location={{ endAt: '2022-10-10T00:00:00Z' }} />
+      <LocationBadge location={{ endAt: '2022-10-25T00:00:00Z' }} />
     );
     expect(container).toMatchSnapshot();
   });
@@ -31,9 +34,12 @@ describe('snapshots', () => {
 });
 
 describe('contexts', () => {
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2022-12-25T00:00:00Z'));
+  });
   it('renders offline location', async () => {
     const { findByTestId } = render(
-      <LocationBadge location={{ endAt: '2022-10-10T00:00:00Z' }} />
+      <LocationBadge location={{ endAt: '2022-10-25T00:00:00Z' }} />
     );
     const container = await findByTestId('badge');
 
@@ -41,7 +47,7 @@ describe('contexts', () => {
     expect(container.childNodes).toHaveLength(2);
 
     const tooltip = await findByTestId('tooltip');
-    expect(tooltip).toHaveTextContent('October 10, 2022 00:00');
+    expect(tooltip).toHaveTextContent('October 25, 2022 00:00');
   });
 
   it('renders offline location without location information', async () => {

--- a/web/ui/src/components/Badge/__tests__/__snapshots__/LocationBadge.test.tsx.snap
+++ b/web/ui/src/components/Badge/__tests__/__snapshots__/LocationBadge.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`snapshots renders LocationBadge with offline location unchanged 1`] = `
       <span
         class=""
       >
-        October 10, 2022 00:00
+        October 25, 2022 00:00
       </span>
     </div>
     <div


### PR DESCRIPTION
**Relative Issues:** Resolve #371 

**Describe the pull request**

The time has hardcoded and the relative time fromNow is not fixed. To prevent a false positive errors in test suite, set the system time for location badge tests to 25/12/2022 and calcul `2 months ago` from 25/10/2022

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no

**Additional context**

I also add two tasks to help tests suite in devcontainer
