### PR TITLE
fix: mismatch between campus data and intra data

### DIFF
--- a/web/ui/src/lib/clustersMap/campus/seoul.ts
+++ b/web/ui/src/lib/clustersMap/campus/seoul.ts
@@ -183,7 +183,7 @@ export class Seoul extends Campus implements ICampus {
         ],
       }),
       new Cluster({
-        identifier: 'cX-1',
+        identifier: 'cx1',
         totalWorkspaces: 28,
         // prettier-ignore
         map: [
@@ -208,7 +208,7 @@ export class Seoul extends Campus implements ICampus {
         ],
       }),
       new Cluster({
-        identifier: 'cX-2',
+        identifier: 'cx2',
         totalWorkspaces: 56,
         // prettier-ignore
         map: [


### PR DESCRIPTION
**Describe the pull request**
The data sended by the intranet is not align with the campus data on our lib. The prefix of cluster must be `cx1` and not `cX-1`

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no