### PR TITLE
chore: disable ci on tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - v*
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
**Describe the pull request**
Start a new full ci on tags is not necessary and create double run on main branch rules

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no
