### PR TITLE
fix: bump loki storage

### DIFF
--- a/deploy/stacks/cluster/monitoring.tf
+++ b/deploy/stacks/cluster/monitoring.tf
@@ -380,7 +380,7 @@ module "loki" {
   persistentVolumeClaims = {
     data = {
       accessModes      = ["ReadWriteMany"]
-      storage          = "10Gi"
+      storage          = "15Gi"
       storageClassName = "csi-cinder-classic"
     }
   }


### PR DESCRIPTION
**Describe the pull request**
Due to alert(https://dashboards.s42.app/alerting/grafana/FNlsjC74k/view?orgId=1), we need to bump storage for loki.

**Breaking changes ?**
no
