### PR TITLE
fix: issue has marked stale due to incorrect label name

### DIFF
--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -81,6 +81,7 @@ jobs:
           exempt-assignees: "42Atomys"
 
           enable-statistics: true
+          operations-per-run: 100
 
           days-before-issue-stale: 28
           days-before-issue-close: 14
@@ -99,8 +100,8 @@ jobs:
           close-pr-label: "stale/dead 💀"
           close-pr-message: "This pull request was closed because it has been inactive for 14 days since being marked as stale."
 
-          exempt-issue-labels: "state/confirmed 💜,slate/lock 🔒"
-          exempt-pr-labels: "state/confirmed 💜,slate/lock 🔒"
+          exempt-issue-labels: "state/confirmed 💜,stale/lock 🔒"
+          exempt-pr-labels: "state/confirmed 💜,stale/lock 🔒"
 
           labels-to-add-when-unstale: "stale/unstale 🍖"
           labels-to-remove-when-unstale: "stale/stale 🦴,stale/dead 💀"


### PR DESCRIPTION
**Describe the pull request**
Issues on project has marked stale with the pressence of label https://github.com/42Atomys/stud42/labels/stale%2Flock%20%F0%9F%94%92. This is due to an incorrect label name on configuration. Bump the operations-per-run params from 30 to 100. 

**Checklist**

- [x] I have made the modifications or added tests related to my PR
- [x] I put my PR in Ready for Review only when all the checklist is checked