### PR TITLE
fix: install protoc in ci with setup-protoc to avoid rate-limiting by github

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: "CI"
+name: "Build"
 on:
   workflow_call:
     outputs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI/CD 🚀
 on:
   release:
     types: [prereleased, released]
-  pull_request_target:
+  pull_request:
     types: [ready_for_review, synchronize, reopened, labeled]
   push:
     branches:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI/CD 🚀
 on:
   release:
     types: [prereleased, released]
-  pull_request:
+  pull_request_target:
     types: [ready_for_review, synchronize, reopened, labeled]
   push:
     branches:

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -1,11 +1,11 @@
 name: Plan Management 📝
 on:
   pull_request:
-    types: [opened, reopened, synchronize, unlabeled]
+    types: [opened, reopened, synchronize]
   issues:
-    types: [opened, reopened, edited, unlabeled]
+    types: [opened, reopened, edited]
   schedule:
-    - cron: "42 8,23 * * *"
+    - cron: "42 */2 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -1,9 +1,9 @@
 name: Plan Management 📝
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened]
   issues:
-    types: [opened, reopened, edited]
+    types: [opened, reopened]
   schedule:
     - cron: "42 */2 * * *"
 

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -32,8 +32,13 @@ jobs:
         with:
           go-version: "1.18"
           check-latest: true
+      - name: Setup protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: "22.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate code
-        run: make -f build/Makefile deps generate
+        run: make -f build/Makefile generate
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.4.0
         with:

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -35,7 +35,10 @@ jobs:
       - name: Setup protoc
         uses: arduino/setup-protoc@v1
         with:
-          version: "22.x"
+          # TODO: Update to latest version when the issue
+          # https://github.com/arduino/setup-protoc/issues/33
+          # has been fixed
+          version: "3.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate code
         run: make -f build/Makefile generate

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -46,6 +46,8 @@ jobs:
         uses: golangci/golangci-lint-action@v3.4.0
         with:
           version: latest
+          skip-pkg-cache: true
+          args: -v
 
   frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/previews-cleaner.yaml
+++ b/.github/workflows/previews-cleaner.yaml
@@ -1,6 +1,6 @@
 name: "Previews cleaner 🗑"
 on:
-  pull_request:
+  pull_request_target:
     types: [closed, unlabeled]
 
 jobs:
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'pull_request' && github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'needs-preview-deploy')) ||
-      !contains(github.event.pull_request.labels.*.name, 'needs-preview-deploy')
+      (github.event.action == 'unlabeled' && !contains(github.event.pull_request.labels.*.name, 'needs-preview-deploy'))
     environment:
       name: previews
     env:
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'pull_request' && github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'needs-preview-deploy')) ||
-      !contains(github.event.pull_request.labels.*.name, 'needs-preview-deploy')
+      (github.event.action == 'unlabeled' && !contains(github.event.pull_request.labels.*.name, 'needs-preview-deploy'))
     environment:
       name: previews
     env:

--- a/.github/workflows/previews-cleaner.yaml
+++ b/.github/workflows/previews-cleaner.yaml
@@ -8,7 +8,7 @@ jobs:
     name: "delete ${{ format('pr-{0}', github.event.number) }} terraform"
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'pull_request' && github.event.action == 'closed') ||
+      (github.event_name == 'pull_request' && github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'needs-preview-deploy')) ||
       !contains(github.event.pull_request.labels.*.name, 'needs-preview-deploy')
     environment:
       name: previews
@@ -65,7 +65,7 @@ jobs:
     name: "delete ${{ format('pr-{0}', github.event.number) }} deployment"
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'pull_request' && github.event.action == 'closed') ||
+      (github.event_name == 'pull_request' && github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'needs-preview-deploy')) ||
       !contains(github.event.pull_request.labels.*.name, 'needs-preview-deploy')
     environment:
       name: previews

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -123,8 +123,13 @@ jobs:
         with:
           go-version: "1.18"
           check-latest: true
+      - name: Setup protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: "22.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate code
-        run: make -f build/Makefile deps generate
+        run: make -f build/Makefile generate
       - name: Run Unit tests
         run: |
           go test ./... -coverprofile coverage.out -covermode count

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,8 +10,9 @@ on:
         description: "AWS secret access key"
 jobs:
   terraform:
-    if: (secrets.TERRAFORM_AWS_ACCESS_KEY_ID != "" && TERRAFORM_AWS_SECRET_ACCESS_KEY != "") || (secrets.TERRAFORM_AWS_ACCESS_KEY_ID != null && TERRAFORM_AWS_SECRET_ACCESS_KEY != null)
     runs-on: ubuntu-latest
+    # Allow crash due to fork policy
+    continue-on-error: true
     env:
       # Sandbox is not deployed to the production workspace.
       # Compare the changes when plan with production
@@ -114,6 +115,9 @@ jobs:
                 body: output
               })
             }
+      - name: Terraform Plan Status
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
   backend:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.stack }}-tfplan
-          path: ${{ matrix.stack }}-tfplan
+          path: deploy/stacks/${{ matrix.stack }}/${{ matrix.stack }}-tfplan
           retention-days: 7
       # On pull request, build or change infrastructure according
       # to Terraform configuration files

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,13 +3,14 @@ on:
   workflow_call:
     secrets:
       TERRAFORM_AWS_ACCESS_KEY_ID:
-        required: true
+        required: false
         description: "AWS access key id"
       TERRAFORM_AWS_SECRET_ACCESS_KEY:
-        required: true
+        required: false
         description: "AWS secret access key"
 jobs:
   terraform:
+    if: (secrets.TERRAFORM_AWS_ACCESS_KEY_ID != "" && TERRAFORM_AWS_SECRET_ACCESS_KEY != "") || (secrets.TERRAFORM_AWS_ACCESS_KEY_ID != null && TERRAFORM_AWS_SECRET_ACCESS_KEY != null)
     runs-on: ubuntu-latest
     env:
       # Sandbox is not deployed to the production workspace.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -126,7 +126,10 @@ jobs:
       - name: Setup protoc
         uses: arduino/setup-protoc@v1
         with:
-          version: "22.x"
+          # TODO: Update to latest version when the issue
+          # https://github.com/arduino/setup-protoc/issues/33
+          # has been fixed
+          version: "3.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate code
         run: make -f build/Makefile generate


### PR DESCRIPTION
**Describe the pull request**

The call to Github API is rate-limited due to anonymous authentication. Let the deps in the makefile for local dev but pass [`setup-protoc` Action](https://github.com/marketplace/actions/setup-protoc) to authenticate the repo in the ci and avoid rate-limiting

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no