### PR TITLE
fix: duo time crash when unmarshalled value is null

### DIFF
--- a/pkg/duoapi/time.go
+++ b/pkg/duoapi/time.go
@@ -12,6 +12,9 @@ const duoTimeFormat = "2006-01-02 15:04:05 MST"
 
 func (dt *DuoTime) UnmarshalJSON(b []byte) error {
 	s := strings.Trim(string(b), "\"")
+	if s == "null" {
+		return nil
+	}
 	t, err := time.Parse(duoTimeFormat, s)
 	if err != nil {
 		t2, err := time.Parse(time.RFC3339, s)
@@ -25,6 +28,9 @@ func (dt *DuoTime) UnmarshalJSON(b []byte) error {
 }
 
 func (dt DuoTime) MarshalJSON() ([]byte, error) {
+	if dt.Time().IsZero() {
+		return []byte("null"), nil
+	}
 	return json.Marshal(dt.Time())
 }
 
@@ -37,6 +43,10 @@ func (dt *DuoTime) NillableTime() *time.Time {
 		return nil
 	}
 
+	if dt.Time().IsZero() {
+		return nil
+	}
+
 	nt := dt.Time()
 	return &nt
 }
@@ -46,5 +56,9 @@ func (dt DuoTime) Format(s string) string {
 }
 
 func (dt DuoTime) String() string {
-	return dt.Time().String()
+	if dt.Time().IsZero() {
+		return ""
+	}
+
+	return dt.Time().Format(time.RFC3339)
 }

--- a/pkg/duoapi/time_test.go
+++ b/pkg/duoapi/time_test.go
@@ -1,0 +1,159 @@
+package duoapi
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeUnmarshall(t *testing.T) {
+	tests := []struct {
+		name               string
+		input              string
+		expected           string
+		expectedErr        bool
+		expectedTimeIsZero bool
+	}{
+		{
+			"DuoTime with timezone",
+			"2018-09-26 14:00:00 UTC",
+			"2018-09-26 14:00:00",
+			false,
+			false,
+		},
+		{
+			"DuoTime in format RFC3339",
+			"2018-09-26T14:00:00Z",
+			"2018-09-26 14:00:00",
+			false,
+			false,
+		},
+		{
+			"DuoTime in format RFC3339 with timezone",
+			"2018-09-26T14:00:00+02:00",
+			"2018-09-26 14:00:00",
+			false,
+			false,
+		},
+		{
+			"DuoTime is null",
+			"null",
+			"0001-01-01 00:00:00",
+			false,
+			true,
+		},
+		{
+			"DuoTime is empty",
+			"",
+			"0001-01-01 00:00:00",
+			true,
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var dt DuoTime
+			if test.expectedErr {
+				assert.Error(t, dt.UnmarshalJSON([]byte(test.input)))
+				assert.True(t, dt.Time().IsZero())
+				return
+			} else {
+				assert.NoError(t, dt.UnmarshalJSON([]byte(test.input)))
+			}
+
+			assert.Equal(t, test.expectedTimeIsZero, dt.Time().IsZero())
+			assert.Equal(t, test.expected, dt.Format("2006-01-02 15:04:05"))
+		})
+	}
+}
+
+func TestTimeMarshall(t *testing.T) {
+	tests := []struct {
+		name               string
+		input              DuoTime
+		expectedMarshal    string
+		expectedStringFunc string
+		expectedTimeIsZero bool
+	}{
+		{
+			"DuoTime with timezone",
+			DuoTime(time.Date(2018, 9, 26, 14, 0, 0, 0, time.UTC)),
+			"\"2018-09-26T14:00:00Z\"",
+			"2018-09-26T14:00:00Z",
+			false,
+		},
+		{
+			"DuoTime in format RFC3339",
+			DuoTime(time.Date(2018, 9, 26, 14, 0, 0, 0, time.UTC)),
+			"\"2018-09-26T14:00:00Z\"",
+			"2018-09-26T14:00:00Z",
+			false,
+		},
+		{
+			"DuoTime in format RFC3339 with timezone",
+			DuoTime(time.Date(2018, 9, 26, 14, 0, 0, 0, time.FixedZone("UTC+2", 2*60*60))),
+			"\"2018-09-26T14:00:00+02:00\"",
+			"2018-09-26T14:00:00+02:00",
+			false,
+		},
+		{
+			"DuoTime is zero",
+			DuoTime(time.Time{}),
+			"null",
+			"",
+			true,
+		},
+		{
+			"DuoTime is empty",
+			DuoTime{},
+			"null",
+			"",
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expectedTimeIsZero, test.input.Time().IsZero())
+			b, err := test.input.MarshalJSON()
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedMarshal, string(b))
+			assert.Equal(t, test.expectedStringFunc, test.input.String())
+		})
+	}
+}
+
+func TestNillableTime(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       *DuoTime
+		expectedNil bool
+	}{
+		{
+			"DuoTime is nil",
+			nil,
+			true,
+		},
+		{
+			"DuoTime is not nil but empty",
+			&DuoTime{},
+			true,
+		},
+		{
+			"DuoTime is not nil and not empty",
+			func() *DuoTime {
+				dt := DuoTime(time.Now())
+				return &dt
+			}(),
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expectedNil, test.input.NillableTime() == nil)
+		})
+	}
+}


### PR DESCRIPTION
**Describe the pull request**

The DuoTime have incorrect behavior and crash when duotime byte is a null value. Fix it and add a test suit on the file

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no