### PR TITLE
fix: delete a location on cascade delete the associated user

### DIFF
--- a/internal/models/schema/user.go
+++ b/internal/models/schema/user.go
@@ -63,11 +63,11 @@ func (User) Edges() []ent.Edge {
 		edge.To("current_location", Location.Type).
 			Unique().
 			Field("current_location_id").
-			Annotations(entsql.Annotation{OnDelete: entsql.Cascade}),
+			Annotations(entsql.Annotation{OnDelete: entsql.SetNull}),
 		edge.To("last_location", Location.Type).
 			Unique().
 			Field("last_location_id").
-			Annotations(entsql.Annotation{OnDelete: entsql.Cascade}),
+			Annotations(entsql.Annotation{OnDelete: entsql.SetNull}),
 		edge.To("current_campus", Campus.Type).
 			Unique().
 			Field("current_campus_id"),


### PR DESCRIPTION
**Describe the pull request**

When we do a manual operation on database and this operation delete a locations, the deletion of the location delete the associated user. 

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no
