### PR TITLE
fix: stars cause multiples useless render

### DIFF
--- a/web/ui/src/lib/github.tsx
+++ b/web/ui/src/lib/github.tsx
@@ -1,5 +1,6 @@
+import useSessionStorage from '@lib/useSessionStorage';
 import axios from 'axios';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect } from 'react';
 
 export interface Repository {
   id?: number;
@@ -131,12 +132,12 @@ export const Star = (): JSX.Element => {
     }
   }, []);
 
-  const [stars, setStars] = useState(0);
+  const [stars, setStars] = useSessionStorage('github-stars', 0);
   useEffect(() => {
     getRepo().then(({ stargazers_count }) => {
       setStars(isNaN(Number(stargazers_count)) ? 0 : Number(stargazers_count));
     });
-  }, [getRepo]);
+  }, [getRepo, setStars]);
 
   return (
     <a
@@ -147,7 +148,9 @@ export const Star = (): JSX.Element => {
     >
       <i className="fa-regular fa-star"></i>
       <span className="pl-3 font-medium">Star</span>
-      <span className="pl-3 font-medium">{stars}</span>
+      <span className="pl-3 font-medium" suppressHydrationWarning>
+        {stars}
+      </span>
     </a>
   );
 };

--- a/web/ui/src/lib/useSessionStorage.ts
+++ b/web/ui/src/lib/useSessionStorage.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2020 Julien CARON
+// Credits go to https://github.com/juliencrn/usehooks-ts
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { parseJSONSafely } from './jsonParser';
+import useEventCallback from './useEventCallback';
+import useEventListener from './useEventListener';
+
+declare global {
+  interface WindowEventMap {
+    'session-storage': CustomEvent;
+  }
+}
+
+type SetValue<T> = Dispatch<SetStateAction<T>>;
+
+function useSessionStorage<T>(
+  key: string,
+  initialValue: T
+): [T, SetValue<T>, boolean] {
+  const alreadyPresentOnSessionStorage = useRef(true);
+  // Get from session storage then
+  // parse stored json or return initialValue
+  const readValue = useCallback((): T => {
+    // Prevent build error "window is undefined" but keep keep working
+    if (typeof window === 'undefined') {
+      return initialValue;
+    }
+
+    try {
+      const item = window.sessionStorage.getItem(key);
+      return item ? (parseJSONSafely(item) as T) : initialValue;
+    } catch (error) {
+      alreadyPresentOnSessionStorage.current = false;
+      return initialValue;
+    }
+  }, [initialValue, key]);
+
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState<T>(readValue);
+
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to sessionStorage.
+  const setValue: SetValue<T> = useEventCallback((value) => {
+    // Prevent build error "window is undefined" but keeps working
+    if (typeof window == 'undefined') {
+      return;
+    }
+
+    try {
+      // Allow value to be a function so we have the same API as useState
+      const newValue = value instanceof Function ? value(storedValue) : value;
+
+      // Save to session storage
+      window.sessionStorage.setItem(key, JSON.stringify(newValue));
+
+      // Save state
+      setStoredValue(newValue);
+
+      // We dispatch a custom event so every useSessionStorage hook are notified
+      window.dispatchEvent(new Event('session-storage'));
+    } catch (error) {
+      alreadyPresentOnSessionStorage.current = false;
+      return initialValue;
+    }
+  });
+
+  useEffect(() => {
+    setStoredValue(readValue());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleStorageChange = useCallback(
+    (event: StorageEvent | CustomEvent) => {
+      if ((event as StorageEvent)?.key && (event as StorageEvent).key !== key) {
+        return;
+      }
+      setStoredValue(readValue());
+    },
+    [key, readValue]
+  );
+
+  // this only works for other documents, not the current one
+  useEventListener('storage', handleStorageChange);
+
+  // this is a custom event, triggered in writeValueToSessionStorage
+  // See: useSessionStorage()
+  useEventListener('session-storage', handleStorageChange);
+
+  return [storedValue, setValue, alreadyPresentOnSessionStorage.current];
+}
+
+export default useSessionStorage;


### PR DESCRIPTION
**Describe the pull request**

The component `Star` for github star information is re-render 4 times on each page and cause useless re-render. Rework this Component to store the star count in session data. This data is not usefull and can be approximated 

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no