### PR TITLE
chore: bump loki storage due to app usage

### DIFF
--- a/deploy/stacks/cluster/monitoring.tf
+++ b/deploy/stacks/cluster/monitoring.tf
@@ -380,7 +380,7 @@ module "loki" {
   persistentVolumeClaims = {
     data = {
       accessModes      = ["ReadWriteMany"]
-      storage          = "15Gi"
+      storage          = "25Gi"
       storageClassName = "csi-cinder-classic"
     }
   }


### PR DESCRIPTION
**Relative Issues:** https://discord.com/channels/248936708379246593/1023378285935198208/1091194060896743525

**Describe the pull request**
This pull request aims to bump the Loki storage capacity for our monitoring tool due to an increase in app usage. This will ensure that our monitoring tool continues to function smoothly, without running into storage limitations that could lead to a degraded monitoring experience.

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no

**Additional context**
As our application usage continues to grow, it is crucial to scale our monitoring tool's storage capacity accordingly. This PR ensures that we stay ahead of the curve and maintain a high level of monitoring service for our application infrastructure.
