### PR TITLE
fix: increase timeout due to 42 api slow response time

### DIFF
--- a/web/ui/src/pages/api/auth/[...nextauth].ts
+++ b/web/ui/src/pages/api/auth/[...nextauth].ts
@@ -23,6 +23,11 @@ export default NextAuth({
       // unique and not editable by the user. The user is already present on database
       // when he be connected on cluster before.
       allowDangerousEmailAccountLinking: true,
+      // 42 API is slow sometimes and we need to increase the timeout
+      // to avoid 500 Gateway Timeout error.
+      httpOptions: {
+        timeout: 10000,
+      },
     }),
     GithubProvider({
       clientId: process.env.GITHUB_ID as string,


### PR DESCRIPTION
**Describe the pull request**
This pull request addresses the issue of slow response times from the 42 API by temporarily increasing the timeout duration. This fix will help to prevent potential issues with the application's performance and user experience, allowing for more efficient handling of requests and improved stability when dealing with slower API responses. Please note that this is a temporary solution, and we will revert to the previous timeout settings once the intra-team resolves the underlying issue with the 42 API's response time.

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no

**Additional context**

https://42born2code.slack.com/archives/C0FEKP3P1/p1680973550018469
