### PR TITLE
fix: initialize sentry for edge runtime

### DIFF
--- a/web/ui/sentry.edge.config.js
+++ b/web/ui/sentry.edge.config.js
@@ -1,0 +1,24 @@
+// This file configures the initialization of Sentry on the server.
+// The config you add here will be used whenever the server handles a request.
+// https://docs.sentry.io/platforms/javascript/guides/nextjs/
+
+import { BrowserTracing } from '@sentry/browser';
+import * as Sentry from '@sentry/nextjs';
+
+const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+if (process.env.NODE_ENV && process.env.NODE_ENV !== 'development') {
+  Sentry.init({
+    dsn: SENTRY_DSN,
+    integrations: [new BrowserTracing()],
+    // Adjust this value in production, or use tracesSampler for greater control
+    tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.2 : 0,
+    sampleRate: 1,
+    // ...
+    // Note: if you want to override the automatic release value, do not set a
+    // `release` value here - use the environment variable `SENTRY_RELEASE`, so
+    // that it will also get attached to your source maps
+    release: `stud42@${process.env.APP_VERSION || 'dev'}`,
+    environment: process.env.NODE_ENV,
+  });
+}


### PR DESCRIPTION
**Describe the pull request**

This pull request addresses the issue of Sentry not being initialized for the edge runtime environment. The fix ensures that Sentry is properly set up to capture and report errors and performance metrics from the edge runtime. By initializing Sentry for edge runtime, we can better monitor and troubleshoot issues that may arise in this environment, leading to an improved overall application experience and more effective error tracking.

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no