### PR TITLE
fix: all cli command try to connect to cache and database

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ var rootCmd = &cobra.Command{
 
 		keyValueStoreUrl := viper.GetString("keyvalue-store-url")
 		if keyValueStoreUrl != "" {
+			log.Info().Msg("Key-value store URL is set, connecting to it...")
 			cacheClient, err = cache.NewClient(viper.GetString("keyvalue-store-url"))
 			if err != nil {
 				log.Fatal().Err(err).Msg("failed to create cache")
@@ -33,12 +34,16 @@ var rootCmd = &cobra.Command{
 			cmd.SetContext(context.WithValue(cmd.Context(), keyValueCtxKey{}, cacheClient))
 		}
 
-		if modelsutils.Connect(cacheClient) != nil {
-			log.Fatal().Msg("Failed to connect to database")
-		}
+		if viper.GetString("database-url") != "" {
+			log.Info().Msg("Database URL is set, connecting to database...")
+			if modelsutils.Connect(cacheClient) != nil {
+				log.Fatal().Msg("Failed to connect to database")
+			}
 
-		if err := modelsutils.Migrate(); err != nil {
-			log.Fatal().Err(err).Msg("failed to migrate database")
+			log.Info().Msg("Migrating database...")
+			if err := modelsutils.Migrate(); err != nil {
+				log.Fatal().Err(err).Msg("failed to migrate database")
+			}
 		}
 	},
 }


### PR DESCRIPTION
**Describe the pull request**
This pull request addresses an issue where all command-line interface (CLI) commands attempt to connect to the cache and database, regardless of whether these connections are necessary for the command. The fix involves updating the CLI command behavior, so that each command only attempts to connect to the cache and database when required.

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no