### PR TITLE
fix: production block s3 upload due to cors

### DIFF
--- a/web/ui/src/pages/settings/profile.tsx
+++ b/web/ui/src/pages/settings/profile.tsx
@@ -94,6 +94,7 @@ const ProfileSettingPage: NextPage<PageProps> = () => {
                     const presignedURL = new URL(data!.presignedUploadURL);
                     fetch(presignedURL, {
                       method: 'PUT',
+                      mode: 'no-cors',
                       body: coverFile,
                       headers: { 'Content-Type': coverFile.type },
                     }).then(async () => {


### PR DESCRIPTION
**Describe the pull request**
This pull request addresses an issue where uploads to S3 in the production environment are being blocked due to CORS (Cross-Origin Resource Sharing) issues. The fix involves changing the fetch mode to 'no-cors', thereby allowing these uploads to proceed without triggering CORS restrictions.

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no