### PR TITLE
fix: error and real limitation of user cover doesn't match

### DIFF
--- a/internal/api/api.resolvers.go
+++ b/internal/api/api.resolvers.go
@@ -465,8 +465,8 @@ func (r *queryResolver) PresignedUploadURL(ctx context.Context, contentType stri
 	}
 
 	// Validate the content length
-	const _1MB = 1 * 1024 * 1024
-	if contentLength > _1MB {
+	const _5MB = 5 * 1024 * 1024
+	if contentLength > _5MB {
 		return "", fmt.Errorf("invalid content length. Must be less than 5MB")
 	}
 


### PR DESCRIPTION
**Describe the pull request**
This pull request addresses an issue where the error message and the actual limitation of a user's cover do not match.

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
no