### PR TITLE
fix: search loader is displayed for eternity

### DIFF
--- a/web/ui/src/components/Search/Search.tsx
+++ b/web/ui/src/components/Search/Search.tsx
@@ -40,7 +40,7 @@ export const Search: SearchComponent = ({
             setLoader(true);
             setSelectedUser(user);
 
-            action(user);
+            action(user).finally(() => setLoader(false));
           }}
         >
           {({ open }) => (

--- a/web/ui/src/components/Search/types.d.ts
+++ b/web/ui/src/components/Search/types.d.ts
@@ -3,7 +3,7 @@ import { SearchUserQueryVariables, User } from '@graphql.d';
 export type SearchComponent = React.ComponentType<SearchProps>;
 
 export type SearchProps = {
-  action: (user: User) => Promise;
+  action: (user: User) => Promise<any>;
   placeholder: string;
   searchVariables?: Partial<SearchUserQueryVariables>;
   icon: string;


### PR DESCRIPTION
**Describe the pull request**
This pull request addresses an issue where the search loader is displayed indefinitely, which can give users the impression that the application is stuck or unresponsive. The fix involves implementing proper termination conditions for the search loader, ensuring that it is displayed only while a search operation is in progress and hidden once the operation is complete. This modification will enhance the user experience by providing more accurate feedback on the search process, thereby preventing potential confusion and frustration.

**Checklist**

- [x] I have made the modifications or added tests related to my PR
- [x] I have run the tests and linters locally and they pass
- [x] I have added/updated the documentation for my RP
