### PR TITLE
fix: long name on user card overflow without truncate

### DIFF
--- a/web/ui/src/components/UserCard/UserCard.tsx
+++ b/web/ui/src/components/UserCard/UserCard.tsx
@@ -23,8 +23,9 @@ export const UserCard: React.FC<PropsWithClassName<UserCardProps>> = ({
   return (
     <div
       className={classNames(
+        '[--card-width:200px]',
         'relative group',
-        'text-center grow-[1] min-w-[200px] max-w-[200px] transition-all',
+        'text-center grow-[1] min-w-[var(--card-width)] max-w-[var(--card-width)] transition-all',
         'rounded-lg border-2 border-transparent hover:cursor-pointer',
         className
       )}
@@ -72,7 +73,10 @@ export const UserCard: React.FC<PropsWithClassName<UserCardProps>> = ({
               </Tooltip>
             )}
           </h2>
-          <Name className="font-light min-w-0 w-full" user={user} />
+          <Name
+            className="font-light min-w-0 w-[calc(var(--card-width)_-_1rem)]"
+            user={user}
+          />
           {user.nickname && user.nickname !== '' && (
             <p className="flex justify-start items-center space-x-1 my-1 text-sm">
               <AkaBadgy /> <span>{user.nickname}</span>


### PR DESCRIPTION
**Describe the pull request**
This pull request addresses an issue where long names on user cards are overflowing their containers without truncation, disrupting the visual design and potentially hindering readability. The fix involves implementing CSS rules to correctly truncate long names with an ellipsis, thereby preserving the design integrity of the user card and enhancing readability. 

**Checklist**

- [x] I have made the modifications or added tests related to my PR
- [x] I have run the tests and linters locally and they pass
- [x] I have added/updated the documentation for my RP