### PR TITLE
fix: upload to s3 in ovh differ than s3 specs

### DIFF
--- a/config/stud42.example.yaml
+++ b/config/stud42.example.yaml
@@ -9,6 +9,11 @@ api:
       bucket: s42-users
       region: europe-west1
       endpoint: http://localhost:9000
+      # forcePathStyle is used to force the usage of the path style
+      # in the endpoint. This is used to use minio as a S3 compatible
+      # storage in local development, or in production with a provider
+      # that does not support the virtual host style.
+      forcePathStyle: true
 
 # Interface relatives configurations
 interface: {}

--- a/deploy/stacks/apps/configs/stud42/stud42.yaml.tftpl
+++ b/deploy/stacks/apps/configs/stud42/stud42.yaml.tftpl
@@ -5,6 +5,7 @@ api:
       bucket: s42-users
       region: gra
       endpoint: https://s3.gra.io.cloud.ovh.net
+      forcePathStyle: false
 
 
 # Interface relatives configurations

--- a/internal/api/api.resolvers.go
+++ b/internal/api/api.resolvers.go
@@ -486,19 +486,18 @@ func (r *queryResolver) PresignedUploadURL(ctx context.Context, contentType stri
 		aws.NewConfig().
 			WithEndpoint(viper.GetString("api.s3.users.endpoint")).
 			WithRegion(viper.GetString("api.s3.users.region")).
-			WithCredentials(credentials.NewCredentials(&credentials.EnvProvider{})),
-		&aws.Config{
-			S3ForcePathStyle: aws.Bool(true),
-		},
+			WithCredentials(credentials.NewCredentials(&credentials.EnvProvider{})).
+			WithS3ForcePathStyle(viper.GetBool("api.s3.users.forcePathStyle")),
 	)
 	request, _ := svc.PutObjectRequest(&s3.PutObjectInput{
 		Bucket:        aws.String(viper.GetString("api.s3.users.bucket")),
 		Key:           aws.String(strings.ToLower(kind.String()) + "/" + cu.ID.String() + "_" + uuid.NewString() + extension[0]),
 		ContentType:   aws.String(contentType),
 		ContentLength: aws.Int64(int64(contentLength)),
+		ACL:           aws.String("public-read"),
 	})
 	// Create the pre-signed url with an expiry
-	url, err := request.Presign(time.Minute)
+	url, err := request.Presign(5 * time.Minute)
 	if err != nil {
 		fmt.Println("Failed to generate a pre-signed url: ", err)
 		return "", err

--- a/web/ui/src/pages/settings/profile.tsx
+++ b/web/ui/src/pages/settings/profile.tsx
@@ -109,7 +109,11 @@ const ProfileSettingPage: NextPage<PageProps> = () => {
                     fetch(presignedURL, {
                       method: 'PUT',
                       body: coverFile,
-                      headers: { 'Content-Type': coverFile.type },
+                      headers: {
+                        'Content-Type': coverFile.type,
+                        'Content-Length': coverFile.size.toString(),
+                        'x-amz-acl': 'public-read',
+                      },
                     }).then(async (d) => {
                       if (!d.ok) {
                         return addNotification({


### PR DESCRIPTION
**Describe the pull request**
This pull request addresses an issue where the upload process to S3 in OVH differs from the standard S3 specifications. The fix involves aligning the upload process with the standard S3 protocol, ensuring compatibility and smooth operation. This fix allow user to upload and access in public-read aby cover uploaded

**Checklist**

- [x] I have made the modifications or added tests related to my PR
- [x] I have run the tests and linters locally and they pass
- [x] I have added/updated the documentation for my RP