### PR TITLE
fix(auth): duplicated port declaration on auth-service

### DIFF
--- a/deploy/stacks/apps/s42/auth_service.tf
+++ b/deploy/stacks/apps/s42/auth_service.tf
@@ -51,11 +51,6 @@ module "auth_service" {
   }
 
   ports = {
-    signing = {
-      containerPort = 5000
-      istioProtocol = "tls"
-    }
-
     wellknow = {
       containerPort = 5000
       istioProtocol = "http"


### PR DESCRIPTION
**Describe the pull request**
This pull request addresses an issue in the authentication service where a port declaration has been duplicated. The fix involves removing the duplicate declaration, ensuring that the port is defined only once as intended.

**Checklist**

- [x] I have made the modifications or added tests related to my PR
- [x] I have run the tests and linters locally and they pass
- [x] I have added/updated the documentation for my RP