### PR TITLE
feat: add personal workspace entity on cluster map

### DIFF
--- a/web/ui/src/components/ClusterMap/ClusterTableMap.tsx
+++ b/web/ui/src/components/ClusterMap/ClusterTableMap.tsx
@@ -1,4 +1,5 @@
 import Avatar from '@components/Avatar';
+import { Tooltip } from '@components/Tooltip';
 import { useMe } from '@ctx/currentUser';
 import { ClusterMapAvatarSize } from '@graphql.d';
 import classNames from 'classnames';
@@ -112,7 +113,7 @@ export const ClusterWorkspaceWithUser = ({
 };
 
 /**
- * ClusterWorkspace component is used to display a workspace with compouter icon
+ * ClusterWorkspace component is used to display a workspace with computer icon
  * and identifier in a `ClusterRow`
  */
 export const ClusterWorkspace = ({
@@ -128,6 +129,37 @@ export const ClusterWorkspace = ({
         <i className="fa-light fa-computer"></i>
       </span>
       <span className="text-xs">{displayText || identifier}</span>
+    </div>
+  );
+};
+
+/**
+ * ClusterPersonalWorkspace component is used to display a workspace space for
+ * personal computer in a `ClusterRow`
+ */
+export const ClusterPersonalWorkspace = ({
+  identifier,
+  displayText,
+}: {
+  identifier?: string;
+  displayText?: string;
+}) => {
+  const hasDisplayText = displayText || identifier;
+  return (
+    <div className="flex flex-1 flex-col justify-center items-center m-0.5 rounded text-slate-500">
+      <Tooltip
+        text="Personal Workspace"
+        size="xs"
+        color="black"
+        direction="top"
+      >
+        <span className="opacity-50">
+          <i className="fa-light fa-laptop"></i>
+        </span>
+        {hasDisplayText && (
+          <span className="text-xs">{displayText || identifier}</span>
+        )}
+      </Tooltip>
     </div>
   );
 };

--- a/web/ui/src/components/ClusterMap/index.ts
+++ b/web/ui/src/components/ClusterMap/index.ts
@@ -1,5 +1,6 @@
 export {
   ClusterEmpty,
+  ClusterPersonalWorkspace,
   ClusterPillar,
   ClusterRow,
   ClusterTableMap,
@@ -7,4 +8,4 @@ export {
   ClusterWorkspaceWithUser,
 } from './ClusterTableMap';
 export type { ClusterContainerProps, MapLocation } from './types';
-export { extractandRemoveNode, extractNode } from './utils';
+export { extractNode, extractandRemoveNode } from './utils';

--- a/web/ui/src/lib/clustersMap/types.d.ts
+++ b/web/ui/src/lib/clustersMap/types.d.ts
@@ -15,10 +15,16 @@ export type CampusNames =
  * W = WORKSPACE
  * T = TEXT
  */
-export type ClusterMapEntity = null | Pillar | Workspace | Text;
+export type ClusterMapEntity =
+  | null
+  | Pillar
+  | Workspace
+  | PersonalWorkspace
+  | Text;
 
 type Pillar = 'P';
 type Workspace = `W:${string}`;
+type PersonalWorkspace = 'PW' | `PW:${string}`;
 type Text = `T:${string}`;
 
 /**

--- a/web/ui/src/pages/clusters/[campusName]/[cluster].tsx
+++ b/web/ui/src/pages/clusters/[campusName]/[cluster].tsx
@@ -1,6 +1,7 @@
 import {
   ClusterContainerProps,
   ClusterEmpty,
+  ClusterPersonalWorkspace,
   ClusterPillar,
   ClusterRow,
   ClusterTableMap,
@@ -9,7 +10,7 @@ import {
   extractNode,
 } from '@components/ClusterMap';
 import { ClusterContainer } from '@components/ClusterMap/ClusterContainer';
-import { Campuses, CampusNames } from '@lib/clustersMap';
+import { CampusNames, Campuses } from '@lib/clustersMap';
 import {
   GetStaticPaths,
   GetStaticPathsResult,
@@ -39,10 +40,19 @@ export const IndexPage: NextPage<
 
                 if (entity === null) return <ClusterEmpty key={key} />;
                 if (entity === 'P') return <ClusterPillar key={key} />;
-                if (entity.startsWith('T:'))
+                if (entity.startsWith('PW')) {
+                  return (
+                    <ClusterPersonalWorkspace
+                      key={key}
+                      displayText={entity.slice(3)}
+                    />
+                  );
+                }
+                if (entity.startsWith('T:')) {
                   return (
                     <ClusterEmpty key={key} displayText={entity.slice(2)} />
                   );
+                }
 
                 const identifier = entity.slice(2);
                 const loc = extractNode(locations, identifier);


### PR DESCRIPTION
**Describe the pull request**
This pull request introduces a new entity that adds a personal workspace entity on the cluster map. The addition of personal workspaces on the map provides users with a visual representation of their personal workspace within the cluster. This addition aims to improve user interaction and understanding of their workspace distribution in the cluster, allowing users to easily identify where they can work with their personal computers.

**Checklist**

- [x] I have made the modifications or added tests related to my PR
- [x] I have run the tests and linters locally and they pass
- [x] I have added/updated the documentation for my RP
