### PR TITLE
fix: paris campus locations regexp

### DIFF
--- a/web/ui/src/components/Badge/__tests__/LocationBadge.test.tsx
+++ b/web/ui/src/components/Badge/__tests__/LocationBadge.test.tsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 const validLocation = {
   beginAt: '2022-10-25T00:00:00Z',
   endAt: null,
-  identifier: 'bess-f1r1s1',
+  identifier: 'paul-f1Ar1s1',
   campus: {
     country: 'France',
     name: 'Paris',
@@ -79,7 +79,7 @@ describe('contexts', () => {
 
     const link = await findByTestId('location-badge-link');
     expect(link.getAttribute('href')).toContain(
-      `/clusters/paris/f1?identifier=${validLocation.identifier}`
+      `/clusters/paris/paul-f1A?identifier=${validLocation.identifier}`
     );
   });
 });

--- a/web/ui/src/components/Badge/__tests__/__snapshots__/LocationBadge.test.tsx.snap
+++ b/web/ui/src/components/Badge/__tests__/__snapshots__/LocationBadge.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`snapshots renders LocationBadge with online location unchanged 1`] = `
 <div>
   <a
     data-testid="location-badge-link"
-    href="/clusters/paris/f1?identifier=bess-f1r1s1"
+    href="/clusters/paris/paul-f1A?identifier=paul-f1Ar1s1"
   >
     <div
       class="transition-colors flex w-fit text-gray items-center rounded-full border py-1 px-2 my-2 text-sm bg-emerald-500/20 border-emerald-500 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-500/50 max-w-full"
@@ -70,7 +70,7 @@ exports[`snapshots renders LocationBadge with online location unchanged 1`] = `
       <span
         class="text-sm mx-1 flex-1 truncate"
       >
-        bess-f1r1s1
+        paul-f1Ar1s1
       </span>
       <img
         alt="🇫🇷"

--- a/web/ui/src/lib/clustersMap/campus/paris.ts
+++ b/web/ui/src/lib/clustersMap/campus/paris.ts
@@ -9,7 +9,7 @@ export class Paris extends Campus implements ICampus {
   name = (): CampusNames => 'paris';
 
   extractorRegexp = (): RegExp =>
-    /(?<building>bess|paul)-(?<clusterWithLetter>f(?<cluster>\d+(?:A|B)?))(?<rowWithLetter>r(?<row>\d+))(?<workspaceWithLetter>s(?<workspace>\d+))/i;
+    /(?<clusterWithLetter>(?<building>bess|paul)-f(?<cluster>\d+(?:A|B)?))(?<rowWithLetter>r(?<row>\d+))(?<workspaceWithLetter>s(?<workspace>\d+))/i;
 
   clusters(): Cluster[] {
     return [

--- a/web/ui/src/lib/searchEngine.ts
+++ b/web/ui/src/lib/searchEngine.ts
@@ -8,18 +8,17 @@ export const clusterURL = (
   identifier: string | null | undefined
 ): string | null => {
   const campusLower = campus?.toLowerCase();
-  const identifierLower = identifier?.toLowerCase();
 
   if (!campusLower || !Object.keys(Campuses).includes(campusLower)) {
     return null;
   }
 
-  if (campusLower && identifierLower) {
+  if (campusLower && identifier) {
     const { clusterWithLetter } =
-      Campuses[campusLower as CampusNames].extractor(identifierLower);
+      Campuses[campusLower as CampusNames].extractor(identifier);
 
     if (clusterWithLetter) {
-      return `/clusters/${campusLower}/${clusterWithLetter}?identifier=${identifierLower}`;
+      return `/clusters/${campusLower}/${clusterWithLetter}?identifier=${identifier}`;
     }
   }
   return null;


### PR DESCRIPTION
The link from the friends page on Paris campus is invalid due to regexp and the fact that location can have uppercase letters
![image](https://github.com/42atomys/stud42/assets/5867379/32673289-7192-4b4c-a51b-f0143500f84b)
