### PR TITLE
fix: deprecated main cursus has displayed first

### DIFF
--- a/web/ui/src/components/UserProfile/UserProfile.tsx
+++ b/web/ui/src/components/UserProfile/UserProfile.tsx
@@ -55,7 +55,7 @@ const CursusProgress: React.FC<{
       (c) => c.cursus?.kind === 'main',
     ) ||
     intraProxy.cursusUsers?.find(
-      // If no main cursus user is found for the old cursus system, find the
+      // If no main cursus user is found for the new cursus system, find the
       // deprecated main cursus user
       (c) => c.cursus?.kind.includes('main'),
     );

--- a/web/ui/src/components/UserProfile/UserProfile.tsx
+++ b/web/ui/src/components/UserProfile/UserProfile.tsx
@@ -49,9 +49,17 @@ const Badges: React.FC<{ flags: UserFlag[] }> = ({ flags }) => {
 const CursusProgress: React.FC<{
   intraProxy: NonNullable<UserProfileQuery['user']>['intraProxy'];
 }> = ({ intraProxy }) => {
-  const mainCursusUser = intraProxy.cursusUsers?.find(
-    (c) => c.cursus?.kind.includes('main'),
-  );
+  const mainCursusUser =
+    intraProxy.cursusUsers?.find(
+      // Find the main cursus user
+      (c) => c.cursus?.kind === 'main',
+    ) ||
+    intraProxy.cursusUsers?.find(
+      // If no main cursus user is found for the old cursus system, find the
+      // deprecated main cursus user
+      (c) => c.cursus?.kind.includes('main'),
+    );
+
   const piscineCursusUser = intraProxy.cursusUsers?.find(
     (c) => c.cursus?.kind.includes('piscine'),
   );


### PR DESCRIPTION
**Describe the pull request**
This pull request addresses an issue where a deprecated main cursus was being displayed first. The fix involves revising the cursus display order to prioritize current cursus over deprecated ones. Fix #479 

**Checklist**
- [x] I have made the modifications or added tests related to my PR
- [x] I have run the tests and linters locally and they pass
- [x] I have added/updated the documentation for my RP