### PR TITLE
fix: incorrect title page of friendships

### DIFF
--- a/web/ui/src/pages/friends/[groupSlug].tsx
+++ b/web/ui/src/pages/friends/[groupSlug].tsx
@@ -102,7 +102,9 @@ const IndexPage: NextPage<PageProps> = () => {
   const hasFollowing = (myFollowings?.length || 0) > 0;
   const currentGroup = myFollowsGroups?.find((g) => g?.slug === groupSlug);
   const pageTitle = currentGroup
-    ? `${currentGroup?.emoji} ${currentGroup?.name} - Friendship - S42`
+    ? `${
+        currentGroup?.emoji + ' ' || ''
+      }${currentGroup?.name} - Friendship - S42`
     : `All Friendship - S42`;
 
   return (


### PR DESCRIPTION
**Describe the pull request**

This pull request fix a display glitch on friendship page title when no emoji are present in the group name. As emoji feature are not implemented yet, the display will be optional.

**Checklist**

- [x] I have made the modifications or added tests related to my PR
- [x] I have run the tests and linters locally and they pass
- [x] I have added/updated the documentation for my RP