### PR TITLE
fix: loader on cluster search bar spin forever

### DIFF
--- a/web/ui/src/components/Search/Search.tsx
+++ b/web/ui/src/components/Search/Search.tsx
@@ -120,7 +120,7 @@ export const Search: SearchComponent = ({
         <span
           className={
             loader
-              ? 'absolute right-2 bg-white dark:bg-slate-950 z-10'
+              ? 'absolute right-2 bg-slate-200 dark:bg-slate-950 z-10'
               : 'hidden'
           }
         >

--- a/web/ui/src/containers/clusters/ClusterSidebar.tsx
+++ b/web/ui/src/containers/clusters/ClusterSidebar.tsx
@@ -86,10 +86,7 @@ export const ClusterSidebar = ({
             user?.currentLocation?.identifier as string,
           );
 
-          if (url) {
-            router.replace(url);
-            return new Promise(() => {});
-          }
+          return url ? router.replace(url) : Promise.reject();
         }}
       />
       <div>


### PR DESCRIPTION
**Describe the pull request**

This PR addresses a bug where the loading spinner in the cluster search bar would continue to spin indefinitely when a user performs a search.

**Checklist**

- [x] I have made the modifications or added tests related to my PR
- [x] I have run the tests and linters locally and they pass
- [x] I have added/updated the documentation for my RP