### PR TITLE
fix: webhooks processor unamrshal empty interface

### DIFF
--- a/internal/webhooks/campus_user.go
+++ b/internal/webhooks/campus_user.go
@@ -12,6 +12,14 @@ type campusUserProcessor struct {
 	duoapi.CampusUserWebhookProcessor
 }
 
+func unmarshalAndProcessCampusUser(data []byte, metadata duoapi.WebhookMetadata, p *processor) error {
+	webhookCampusUser, err := unmarshalWebhook[duoapi.WebhookMetadata, duoapi.CampusUser](data)
+	if err != nil {
+		return err
+	}
+	return webhookCampusUser.Payload.ProcessWebhook(p.ctx, &metadata, &campusUserProcessor{processor: p})
+}
+
 func (p *campusUserProcessor) Create(cu *duoapi.CampusUser, metadata *duoapi.WebhookMetadata) error {
 	// Do nothing if the primary campus is not true. Due to the fact of when an
 	// User switch of campus : the current campus is set to false and the new

--- a/internal/webhooks/location.go
+++ b/internal/webhooks/location.go
@@ -19,6 +19,14 @@ type locationProcessor struct {
 	duoapi.LocationWebhookProcessor[duoapi.LocationUser]
 }
 
+func unmarshalAndProcessLocation(data []byte, metadata duoapi.WebhookMetadata, p *processor) error {
+	webhookLocation, err := unmarshalWebhook[duoapi.WebhookMetadata, duoapi.Location[duoapi.LocationUser]](data)
+	if err != nil {
+		return err
+	}
+	return webhookLocation.Payload.ProcessWebhook(p.ctx, &metadata, &locationProcessor{processor: p})
+}
+
 func (p *locationProcessor) Create(loc *duoapi.Location[duoapi.LocationUser], metadata *duoapi.WebhookMetadata) error {
 	campus, err := p.db.Campus.Query().Where(campus.DuoID(loc.CampusID)).Only(p.ctx)
 	if err != nil {

--- a/internal/webhooks/user.go
+++ b/internal/webhooks/user.go
@@ -13,6 +13,14 @@ type userProcessor struct {
 	duoapi.UserWebhookProcessor
 }
 
+func unmarshalAndProcessUser(data []byte, metadata duoapi.WebhookMetadata, p *processor) error {
+	webhookUser, err := unmarshalWebhook[duoapi.WebhookMetadata, duoapi.User](data)
+	if err != nil {
+		return err
+	}
+	return webhookUser.Payload.ProcessWebhook(p.ctx, &metadata, &userProcessor{processor: p})
+}
+
 func (p *userProcessor) Create(u *duoapi.User, metadata *duoapi.WebhookMetadata) error {
 	ok, err := p.db.User.Query().Where(user.DuoID(u.ID)).Exist(p.ctx)
 	if err != nil && !modelgen.IsNotFound(err) {


### PR DESCRIPTION
**Describe the pull request**

An issue when webhooks are unmarshalled into an interface and not a struct.

**Checklist**

- [x] I have made the modifications or added tests related to my PR
- [x] I have run the tests and linters locally and they pass
- [x] I have added/updated the documentation for my RP