### PR TITLE
fix: intra send location create event for 3b3 users

### DIFF
--- a/internal/webhooks/location.go
+++ b/internal/webhooks/location.go
@@ -3,6 +3,7 @@ package webhooks
 import (
 	"database/sql"
 	"errors"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 
@@ -36,6 +37,11 @@ func (p *locationProcessor) Create(loc *duoapi.Location[duoapi.LocationUser], me
 		}
 		log.Error().Err(err).Msg("Failed to get campus")
 		return err
+	}
+
+	// Skip location for anonymized users
+	if strings.HasPrefix(loc.User.Login, "3b3") {
+		return nil
 	}
 
 	// retrieve or create user in database from the location object received

--- a/internal/webhooks/location.go
+++ b/internal/webhooks/location.go
@@ -71,6 +71,7 @@ func (p *locationProcessor) Create(loc *duoapi.Location[duoapi.LocationUser], me
 
 	return err
 }
+
 func (p *locationProcessor) Close(loc *duoapi.Location[duoapi.LocationUser], metadata *duoapi.WebhookMetadata) error {
 	return modelsutils.WithTx(p.ctx, p.db, func(tx *generated.Tx) error {
 		// Close the location in database
@@ -90,6 +91,7 @@ func (p *locationProcessor) Close(loc *duoapi.Location[duoapi.LocationUser], met
 		return p.unlinkLocation(loc)
 	})
 }
+
 func (p *locationProcessor) Destroy(loc *duoapi.Location[duoapi.LocationUser], metadata *duoapi.WebhookMetadata) error {
 	// Delete the location in database
 	_, err := p.db.Location.Delete().Where(location.DuoID(loc.ID)).Exec(p.ctx)

--- a/pkg/duoapi/locations.go
+++ b/pkg/duoapi/locations.go
@@ -2,7 +2,6 @@ package duoapi
 
 import (
 	"context"
-	"strings"
 )
 
 // LocationsActive returns the list of active locations of a campus
@@ -40,11 +39,6 @@ func (l *Location[LocationUser]) ProcessWebhook(ctx context.Context, metadata *W
 	p, ok := processor.(LocationWebhookProcessor[LocationUser])
 	if !ok {
 		return ErrInvalidWebhookProcessor
-	}
-
-	// Skip location for anonymized users
-	if strings.HasPrefix(l.User.Login, "3b3") {
-		return nil
 	}
 
 	switch metadata.Event {

--- a/pkg/duoapi/locations.go
+++ b/pkg/duoapi/locations.go
@@ -2,6 +2,7 @@ package duoapi
 
 import (
 	"context"
+	"strings"
 )
 
 // LocationsActive returns the list of active locations of a campus
@@ -39,6 +40,11 @@ func (l *Location[LocationUser]) ProcessWebhook(ctx context.Context, metadata *W
 	p, ok := processor.(LocationWebhookProcessor[LocationUser])
 	if !ok {
 		return ErrInvalidWebhookProcessor
+	}
+
+	// Skip location for anonymized users
+	if strings.HasPrefix(l.User.Login, "3b3") {
+		return nil
 	}
 
 	switch metadata.Event {


### PR DESCRIPTION
**Describe the pull request**

This pull request resolves an issue that occurs when the 42 intranet sends an event to the webhook processor to create a new location for an anonymized (3b3-) user. By design, this should never happen on the intra side, but when it does, it causes a significant increase in the size of RabbitMQ. Therefore, I have implemented a protection mechanism to prevent this.

**Checklist**

- [x] I have made the modifications or added tests related to my PR
- [x] I have run the tests and linters locally and they pass
- [x] I have added/updated the documentation for my RP