### PR TITLE
fix: webhook on github sponsorship cause crash due to an error or format

### DIFF
--- a/internal/webhooks/types.go
+++ b/internal/webhooks/types.go
@@ -59,7 +59,9 @@ type githubSponsorshipWebhookPayload struct {
 		} `json:"tier"`
 		// The edited event types include the details about the change when
 		// someone edits a sponsorship to change the privacy.
-		PrivacyLevel string `json:"privacy_level"`
+		PrivacyLevel struct {
+			From string `json:"from"`
+		} `json:"privacy_level"`
 	} `json:"changes"`
 }
 

--- a/pkg/otelgql/otelgql.go
+++ b/pkg/otelgql/otelgql.go
@@ -8,6 +8,7 @@ package otelgql
 
 import (
 	"context"
+	"errors"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler/extension"

--- a/pkg/otelgql/otelgql.go
+++ b/pkg/otelgql/otelgql.go
@@ -84,7 +84,7 @@ func (a Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHand
 	resp := next(ctx)
 	if resp != nil && len(resp.Errors) > 0 {
 		span.SetStatus(codes.Error, resp.Errors.Error())
-		span.RecordError(resp.Errors.Error())
+		span.RecordError(errors.New(resp.Errors.Error()))
 		span.SetAttributes(ResolverErrors(resp.Errors)...)
 	}
 
@@ -115,7 +115,7 @@ func (a Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (inte
 	errList := graphql.GetFieldErrors(ctx, fc)
 	if len(errList) != 0 {
 		span.SetStatus(codes.Error, errList.Error())
-		span.RecordError(errList.Error())
+		span.RecordError(errList)
 		span.SetAttributes(ResolverErrors(errList)...)
 	}
 

--- a/pkg/otelgql/otelgql.go
+++ b/pkg/otelgql/otelgql.go
@@ -84,7 +84,7 @@ func (a Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHand
 	resp := next(ctx)
 	if resp != nil && len(resp.Errors) > 0 {
 		span.SetStatus(codes.Error, resp.Errors.Error())
-		span.RecordError(fmt.Errorf(resp.Errors.Error()))
+		span.RecordError(resp.Errors.Error())
 		span.SetAttributes(ResolverErrors(resp.Errors)...)
 	}
 
@@ -115,7 +115,7 @@ func (a Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (inte
 	errList := graphql.GetFieldErrors(ctx, fc)
 	if len(errList) != 0 {
 		span.SetStatus(codes.Error, errList.Error())
-		span.RecordError(fmt.Errorf(errList.Error()))
+		span.RecordError(errList.Error())
 		span.SetAttributes(ResolverErrors(errList)...)
 	}
 

--- a/pkg/otelgql/otelgql.go
+++ b/pkg/otelgql/otelgql.go
@@ -8,7 +8,6 @@ package otelgql
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler/extension"


### PR DESCRIPTION
**Describe the pull request**

We encountered a critical issue where the webhook associated with GitHub Sponsorships is causing a system crash. The crash occurs due to an unexpected error in the payload format received from the webhook

**Checklist**

- [x] I have made the modifications or added tests related to my PR
- [x] I have run the tests and linters locally and they pass
- [x] I have added/updated the documentation for my RP
